### PR TITLE
Add reduction-trend card above streak (reduce-don't-quit hero)

### DIFF
--- a/app/src/main/java/com/smokless/smokeless/MainActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/MainActivity.kt
@@ -820,6 +820,26 @@ class MainActivity : AppCompatActivity() {
         viewModel.moneySavedFormatted.observe(this) { formatted ->
             binding.sectionRecords.textMoneySaved.text = formatted
         }
+
+        // Observe reduction trend (data, no praise — per design note)
+        viewModel.reductionStats.observe(this) { stats ->
+            updateReductionTrend(stats)
+        }
+    }
+
+    private fun updateReductionTrend(stats: com.smokless.smokeless.util.ScoreCalculator.ReductionStats) {
+        val avgFormat = DecimalFormat("0.#")
+        binding.sectionReductionTrend.textReductionAverage.text = avgFormat.format(stats.rollingAverage7d)
+
+        val velocityText = when {
+            !stats.hasEnoughData -> "Logging — trend appears after 14 days of data"
+            stats.velocityPercent >= 5.0 ->
+                "${DecimalFormat("0").format(stats.velocityPercent)}% less than 30 days ago"
+            stats.velocityPercent <= -5.0 ->
+                "${DecimalFormat("0").format(-stats.velocityPercent)}% more than 30 days ago"
+            else -> "Steady vs. 30 days ago"
+        }
+        binding.sectionReductionTrend.textReductionVelocity.text = velocityText
     }
     
     private fun updateProgressColor(percentage: Double) {

--- a/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
@@ -83,9 +83,13 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     // Money saved data
     private val _moneySaved = MutableLiveData<Float>()
     val moneySaved: LiveData<Float> = _moneySaved
-    
+
     private val _moneySavedFormatted = MutableLiveData<String>()
     val moneySavedFormatted: LiveData<String> = _moneySavedFormatted
+
+    // Reduction trend (reduce-don't-quit hero signal)
+    private val _reductionStats = MutableLiveData<ScoreCalculator.ReductionStats>()
+    val reductionStats: LiveData<ScoreCalculator.ReductionStats> = _reductionStats
     
     private var lastTimestamp = 0L
     private var currentChartPeriod = "month"
@@ -237,7 +241,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private fun calculateAllScores() {
         // Get all sessions for goal calculation
         val allSessions = repository.getAllSessionsSync()
-        
+
+        // Reduction trend — independent of selected period, uses all sessions
+        _reductionStats.postValue(ScoreCalculator.calculateReductionStats(allSessions))
+
         // Calculate goal and progress based on current goal period
         updateGoalForPeriod()
         

--- a/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
@@ -394,6 +394,51 @@ object ScoreCalculator {
     }
     
     /**
+     * Rolling-window reduction stats. Headline metric for the "reduce, don't quit"
+     * frame: dominant signal is gradient (7d avg, change vs prior period), not binary
+     * abstinence. See docs/design-notes/2026-05-13-streak-vs-reduce.md.
+     */
+    data class ReductionStats(
+        val rollingAverage7d: Double,
+        val rollingAverage30d: Double,
+        val velocityPercent: Double, // positive = reducing, negative = increasing
+        val hasEnoughData: Boolean,
+    )
+
+    fun calculateReductionStats(sessions: List<SmokingSession>): ReductionStats {
+        if (sessions.isEmpty()) {
+            return ReductionStats(0.0, 0.0, 0.0, hasEnoughData = false)
+        }
+
+        val now = System.currentTimeMillis()
+        val day = TimeUnit.DAYS.toMillis(1)
+        val start7d = now - 7 * day
+        val start30d = now - 30 * day
+        val startPrior = now - 60 * day // prior 30-day window: [60d, 30d) ago
+
+        val countLast7d = sessions.count { it.timestamp >= start7d }
+        val countLast30d = sessions.count { it.timestamp >= start30d }
+        val countPrior30d = sessions.count { it.timestamp in startPrior until start30d }
+
+        val avg7d = countLast7d / 7.0
+        val avg30d = countLast30d / 30.0
+        val avgPrior = countPrior30d / 30.0
+
+        val firstSession = sessions.minOf { it.timestamp }
+        val trackedDays = ((now - firstSession) / day).toInt() + 1
+        val hasEnoughData = trackedDays >= 14
+
+        val velocity = when {
+            !hasEnoughData -> 0.0
+            avgPrior < 0.01 && avg7d < 0.01 -> 0.0
+            avgPrior < 0.01 -> -100.0 // started smoking from clean baseline
+            else -> ((avgPrior - avg7d) / avgPrior) * 100.0
+        }
+
+        return ReductionStats(avg7d, avg30d, velocity, hasEnoughData)
+    }
+
+    /**
      * Calculate time since last cigarette
      */
     fun calculateTimeSinceLastSmoke(lastTimestamp: Long): Long {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -46,6 +46,8 @@
 
             <include android:id="@+id/sectionHero" layout="@layout/section_hero" />
 
+            <include android:id="@+id/sectionReductionTrend" layout="@layout/section_reduction_trend" />
+
             <include android:id="@+id/sectionQuickStats" layout="@layout/section_quick_stats" />
 
             <include android:id="@+id/sectionStatistics" layout="@layout/section_statistics" />

--- a/app/src/main/res/layout/section_reduction_trend.xml
+++ b/app/src/main/res/layout/section_reduction_trend.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="14dp">
+
+        <TextView
+            android:id="@+id/textReductionTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Reduction Trend"
+            android:textColor="@color/text_primary"
+            android:textSize="19sp"
+            android:fontFamily="sans-serif-bold" />
+
+        <TextView
+            android:id="@+id/textReductionHint"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="📉 7-day average"
+            android:textColor="@color/text_tertiary"
+            android:textSize="12sp"
+            android:fontFamily="sans-serif" />
+
+    </LinearLayout>
+
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="20dp"
+        app:cardBackgroundColor="@color/surface_card"
+        app:cardCornerRadius="22dp"
+        app:cardElevation="0dp"
+        app:strokeWidth="1dp"
+        app:strokeColor="@color/card_border_dim">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="22dp"
+            android:gravity="center_horizontal">
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="bottom">
+
+                <TextView
+                    android:id="@+id/textReductionAverage"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="--"
+                    android:textColor="@color/text_primary"
+                    android:textSize="44sp"
+                    android:fontFamily="sans-serif-black" />
+
+                <TextView
+                    android:id="@+id/textReductionUnit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginBottom="10dp"
+                    android:text="cigs/day"
+                    android:textColor="@color/text_secondary"
+                    android:textSize="14sp"
+                    android:fontFamily="sans-serif" />
+
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/textReductionVelocity"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text=""
+                android:textColor="@color/text_secondary"
+                android:textSize="13sp"
+                android:gravity="center"
+                android:fontFamily="sans-serif" />
+
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
Surfaces a 7-day rolling smokes/day average and a 30-day velocity line ("X% less than 30 days ago") as a new card placed between the hero countdown and the Period Highlights section. The clean-streak card stays put but is now visually demoted below the reduction signal.

Implements **option (1)** from [docs/design-notes/2026-05-13-streak-vs-reduce.md](docs/design-notes/2026-05-13-streak-vs-reduce.md) — the cheapest, no-migration fix for the structural retention bug where the binary clean-streak reset contradicts the app's reduce-don't-quit thesis.

## Why
A user reducing from 20/day → 8/day → 3/day was getting the same `00:00:00` visual slap as a full relapser. The downward trend they actually need was buried. The reduction card makes the gradient signal dominant; the streak survives for users who still want it but no longer monopolizes the feedback narrative.

## Changes
- `ScoreCalculator.ReductionStats` — `avg7d`, `avg30d`, `velocityPercent` vs prior 30-day window. Requires ≥14 days of tracked history before a velocity is shown (avoids whiplash on fresh installs).
- `MainViewModel.reductionStats` LiveData, recalculated in `calculateAllScores()` from all sessions (period-independent).
- `section_reduction_trend.xml` — minimal card matching existing surface styling. Empty-state copy is a data statement, no praise.
- `MainActivity.updateReductionTrend()` — wires the LiveData to the card. Velocity copy is symmetric: "X% less" / "X% more" / "Steady vs. 30 days ago" — never evaluative.

## Test plan
- [x] `./gradlew :app:assembleDebug` succeeds
- [ ] Install on device, verify card renders between hero and Period Highlights
- [ ] With <14 days of data, verify empty-state copy shows
- [ ] With >14 days, log a series of smokes and confirm 7d avg + velocity update
- [ ] Verify card respects light/dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)