### PR TITLE
Route remaining string surfaces through SubstanceCopy (ROADMAP §2.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /captures
 .externalNativeBuild
 .cxx
+.claude/

--- a/app/src/main/java/com/smokless/smokeless/AchievementsActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/AchievementsActivity.kt
@@ -11,6 +11,7 @@ import com.smokless.smokeless.data.AppDatabase
 import com.smokless.smokeless.databinding.ActivityAchievementsBinding
 import com.smokless.smokeless.util.Achievement
 import com.smokless.smokeless.util.AchievementManager
+import com.smokless.smokeless.util.SubstanceCopy
 
 class AchievementsActivity : AppCompatActivity() {
 
@@ -44,8 +45,9 @@ class AchievementsActivity : AppCompatActivity() {
             val hoursSinceLast = if (lastTimestamp > 0) (System.currentTimeMillis() - lastTimestamp) / 3600000 else 0L
             val daysSinceLast = (hoursSinceLast / 24).toInt()
 
+            val copy = SubstanceCopy.forSubstance(SubstanceCopy.primarySubstance(sessions))
             val achievements = AchievementManager.getAllAchievements(
-                daysSinceLast, bestStreak, cravings.size, cleanDays
+                daysSinceLast, bestStreak, cravings.size, cleanDays, copy
             )
 
             val unlockedCount = achievements.count { it.isUnlocked }

--- a/app/src/main/java/com/smokless/smokeless/HealthTimelineActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/HealthTimelineActivity.kt
@@ -14,6 +14,7 @@ import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.smokless.smokeless.data.AppDatabase
 import com.smokless.smokeless.util.HealthBenefits
 import com.smokless.smokeless.util.HealthMilestone
+import com.smokless.smokeless.util.SubstanceCopy
 
 class HealthTimelineActivity : AppCompatActivity() {
 
@@ -33,6 +34,7 @@ class HealthTimelineActivity : AppCompatActivity() {
     private fun loadTimeline() {
         AppDatabase.databaseExecutor.execute {
             val db = AppDatabase.getInstance(application)
+            val sessions = db.smokingSessionDao().getAllSessions()
             val lastTimestamp = db.smokingSessionDao().getLastTimestamp() ?: 0L
             val hoursSmokeFree = if (lastTimestamp > 0)
                 (System.currentTimeMillis() - lastTimestamp) / 3_600_000L
@@ -41,10 +43,11 @@ class HealthTimelineActivity : AppCompatActivity() {
             val milestones = HealthBenefits.getMilestones(hoursSmokeFree)
             val next = HealthBenefits.getNextMilestone(hoursSmokeFree)
             val achieved = milestones.count { it.isAchieved }
+            val copy = SubstanceCopy.forSubstance(SubstanceCopy.primarySubstance(sessions))
 
             runOnUiThread {
                 findViewById<TextView>(R.id.textSmokeFreeTime).text =
-                    formatSmokeFreeLabel(hoursSmokeFree)
+                    formatSmokeFreeLabel(hoursSmokeFree, copy)
 
                 findViewById<TextView>(R.id.textMilestoneProgress).text =
                     "$achieved / ${milestones.size} milestones reached"
@@ -68,13 +71,14 @@ class HealthTimelineActivity : AppCompatActivity() {
         }
     }
 
-    private fun formatSmokeFreeLabel(hours: Long): String {
+    private fun formatSmokeFreeLabel(hours: Long, copy: SubstanceCopy): String {
         if (hours <= 0) return "Tracking from your last log"
         val days = hours / 24
+        val suffix = copy.cleanSuffix
         return when {
-            days >= 365 -> "${days / 365}y ${days % 365}d smoke-free"
-            days >= 1 -> "${days}d ${hours % 24}h smoke-free"
-            else -> "${hours}h smoke-free"
+            days >= 365 -> "${days / 365}y ${days % 365}d $suffix"
+            days >= 1 -> "${days}d ${hours % 24}h $suffix"
+            else -> "${hours}h $suffix"
         }
     }
 

--- a/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
@@ -208,9 +208,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             // Check for major time milestones
             when (hours.toInt()) {
                 24, 72, 168, 720, 2160, 4320, 8760 -> {
+                    val copy = SubstanceCopy.forSubstance(_primarySubstance.value ?: Substance.DEFAULT)
                     NotificationHelper.showEncouragementNotification(
                         getApplication<Application>().applicationContext,
-                        hours.toInt()
+                        hours.toInt(),
+                        copy,
                     )
                 }
             }

--- a/app/src/main/java/com/smokless/smokeless/util/Achievement.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/Achievement.kt
@@ -10,20 +10,25 @@ data class Achievement(
 )
 
 object AchievementManager {
-    
-    fun getStreakAchievements(currentStreak: Int, bestStreak: Int): List<Achievement> {
+
+    fun getStreakAchievements(
+        currentStreak: Int,
+        bestStreak: Int,
+        copy: SubstanceCopy = SubstanceCopy.TOBACCO,
+    ): List<Achievement> {
+        val suffix = copy.cleanSuffix
         val streakAchievements = listOf(
-            Achievement("first_hour", "First Hour", "1 hour smoke-free", "⏰", 1),
-            Achievement("first_day", "Clean Day", "24 hours smoke-free", "🌟", 1),
-            Achievement("three_days", "Breaking Free", "3 days smoke-free", "💪", 3),
-            Achievement("one_week", "Week Warrior", "7 days smoke-free", "🔥", 7),
-            Achievement("two_weeks", "Fortnight Fighter", "14 days smoke-free", "💎", 14),
-            Achievement("one_month", "Monthly Master", "30 days smoke-free", "🏆", 30),
-            Achievement("90_days", "Quarter Champion", "90 days smoke-free", "👑", 90),
-            Achievement("six_months", "Half Year Hero", "180 days smoke-free", "🌈", 180),
-            Achievement("one_year", "Annual Achievement", "365 days smoke-free", "🎊", 365)
+            Achievement("first_hour", "First Hour", "1 hour $suffix", "⏰", 1),
+            Achievement("first_day", "Clean Day", "24 hours $suffix", "🌟", 1),
+            Achievement("three_days", "Breaking Free", "3 days $suffix", "💪", 3),
+            Achievement("one_week", "Week Warrior", "7 days $suffix", "🔥", 7),
+            Achievement("two_weeks", "Fortnight Fighter", "14 days $suffix", "💎", 14),
+            Achievement("one_month", "Monthly Master", "30 days $suffix", "🏆", 30),
+            Achievement("90_days", "Quarter Champion", "90 days $suffix", "👑", 90),
+            Achievement("six_months", "Half Year Hero", "180 days $suffix", "🌈", 180),
+            Achievement("one_year", "Annual Achievement", "365 days $suffix", "🎊", 365)
         )
-        
+
         return streakAchievements.map { achievement ->
             achievement.copy(isUnlocked = bestStreak >= achievement.requirement)
         }
@@ -56,14 +61,26 @@ object AchievementManager {
         }
     }
     
-    fun getAllAchievements(currentStreak: Int, bestStreak: Int, resistedCount: Int, cleanDays: Int): List<Achievement> {
-        return getStreakAchievements(currentStreak, bestStreak) +
+    fun getAllAchievements(
+        currentStreak: Int,
+        bestStreak: Int,
+        resistedCount: Int,
+        cleanDays: Int,
+        copy: SubstanceCopy = SubstanceCopy.TOBACCO,
+    ): List<Achievement> {
+        return getStreakAchievements(currentStreak, bestStreak, copy) +
                getCravingsAchievements(resistedCount) +
                getCleanDaysAchievements(cleanDays)
     }
-    
-    fun getNextAchievement(currentStreak: Int, bestStreak: Int, resistedCount: Int, cleanDays: Int): Achievement? {
-        val all = getAllAchievements(currentStreak, bestStreak, resistedCount, cleanDays)
+
+    fun getNextAchievement(
+        currentStreak: Int,
+        bestStreak: Int,
+        resistedCount: Int,
+        cleanDays: Int,
+        copy: SubstanceCopy = SubstanceCopy.TOBACCO,
+    ): Achievement? {
+        val all = getAllAchievements(currentStreak, bestStreak, resistedCount, cleanDays, copy)
         return all.firstOrNull { !it.isUnlocked }
     }
 }

--- a/app/src/main/java/com/smokless/smokeless/util/NotificationHelper.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/NotificationHelper.kt
@@ -143,17 +143,22 @@ object NotificationHelper {
         }
     }
 
-    fun showEncouragementNotification(context: Context, hours: Int) {
+    fun showEncouragementNotification(
+        context: Context,
+        hours: Int,
+        copy: SubstanceCopy = SubstanceCopy.TOBACCO,
+    ) {
         createNotificationChannel(context)
-        
+
+        val suffix = copy.cleanSuffix
         val messages = mapOf(
-            24 to Pair("🌟 One Full Day!", "You've been smoke-free for 24 hours! Your body is already healing."),
-            72 to Pair("💪 72 Hours Strong!", "Three days smoke-free! The hardest part is behind you."),
-            168 to Pair("🎉 One Week!", "A full week without smoking! You're doing amazing!"),
-            720 to Pair("🏆 One Month!", "30 days smoke-free! This is a huge achievement!"),
-            2160 to Pair("🌈 Three Months!", "Quarter of a year smoke-free! Your health has significantly improved."),
-            4320 to Pair("💎 Six Months!", "Half a year! You've proven you can live smoke-free."),
-            8760 to Pair("🎊 One Year!", "An entire year without smoking! You're an inspiration!")
+            24 to Pair("🌟 One Full Day!", "You've been $suffix for 24 hours! Your body is already healing."),
+            72 to Pair("💪 72 Hours Strong!", "Three days $suffix! The hardest part is behind you."),
+            168 to Pair("🎉 One Week!", "A full week $suffix! You're doing amazing!"),
+            720 to Pair("🏆 One Month!", "30 days $suffix! This is a huge achievement!"),
+            2160 to Pair("🌈 Three Months!", "Quarter of a year $suffix! Your health has significantly improved."),
+            4320 to Pair("💎 Six Months!", "Half a year! You've proven you can live $suffix."),
+            8760 to Pair("🎊 One Year!", "An entire year $suffix! You're an inspiration!")
         )
         
         val message = messages[hours] ?: return

--- a/app/src/main/java/com/smokless/smokeless/util/SubstanceCopy.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/SubstanceCopy.kt
@@ -15,10 +15,12 @@ import java.util.concurrent.TimeUnit
  * pending substance-specific data — see ROADMAP §2.2.
  */
 data class SubstanceCopy(
-    val unit: String,        // "cigarette" / "session"
-    val units: String,       // "cigarettes" / "sessions"
-    val perDay: String,      // headline abbreviation: "cigs/day" / "uses/day"
-    val cleanLabel: String,  // hero label: "SMOKE-FREE FOR" / "CLEAN FOR"
+    val unit: String,         // "cigarette" / "session"
+    val units: String,        // "cigarettes" / "sessions"
+    val perDay: String,       // headline abbreviation: "cigs/day" / "uses/day"
+    val cleanLabel: String,   // hero label: "SMOKE-FREE FOR" / "CLEAN FOR"
+    val cleanSuffix: String,  // inline suffix: "smoke-free" / "clean"
+    val logCta: String,       // widget CTA: "Log smokes to start" / "Log sessions to start"
 ) {
     fun unitFor(count: Long): String = if (count == 1L) unit else units
     fun unitFor(count: Int): String = unitFor(count.toLong())
@@ -29,6 +31,8 @@ data class SubstanceCopy(
             units = "cigarettes",
             perDay = "cigs/day",
             cleanLabel = "SMOKE-FREE FOR",
+            cleanSuffix = "smoke-free",
+            logCta = "Log smokes to start",
         )
 
         val CANNABIS = SubstanceCopy(
@@ -36,6 +40,8 @@ data class SubstanceCopy(
             units = "sessions",
             perDay = "uses/day",
             cleanLabel = "CLEAN FOR",
+            cleanSuffix = "clean",
+            logCta = "Log sessions to start",
         )
 
         fun forSubstance(substance: Substance): SubstanceCopy = when (substance) {

--- a/app/src/main/java/com/smokless/smokeless/widget/SmokelessWidget.kt
+++ b/app/src/main/java/com/smokless/smokeless/widget/SmokelessWidget.kt
@@ -10,6 +10,7 @@ import com.smokless.smokeless.MainActivity
 import com.smokless.smokeless.R
 import com.smokless.smokeless.data.AppDatabase
 import com.smokless.smokeless.util.ScoreCalculator
+import com.smokless.smokeless.util.SubstanceCopy
 
 class SmokelessWidget : AppWidgetProvider() {
 
@@ -55,6 +56,7 @@ class SmokelessWidget : AppWidgetProvider() {
                     val targetInterval = ScoreCalculator.calculateTargetInterval(sessions, difficulty)
 
                     val remaining = targetInterval - timeSince
+                    val copy = SubstanceCopy.forSubstance(SubstanceCopy.primarySubstance(sessions))
 
                     val timerText: String
                     val labelText: String
@@ -64,7 +66,7 @@ class SmokelessWidget : AppWidgetProvider() {
                         val hours = timeSince / 3_600_000
                         val minutes = (timeSince % 3_600_000) / 60_000
                         timerText = "${hours}h ${minutes}m"
-                        labelText = "SMOKE-FREE FOR"
+                        labelText = copy.cleanLabel
                     } else if (remaining > 0) {
                         // Counting down
                         val hours = remaining / 3_600_000
@@ -88,7 +90,7 @@ class SmokelessWidget : AppWidgetProvider() {
                     }
 
                     val streakText = when {
-                        targetInterval <= 0L -> "Log smokes to start"
+                        targetInterval <= 0L -> copy.logCta
                         remaining > 0 -> "Hold on, you've got this!"
                         else -> "Target reached!"
                     }


### PR DESCRIPTION
## Summary
Follows #24. Extends `SubstanceCopy` with two new fields — `cleanSuffix` ("smoke-free" / "clean") and `logCta` ("Log smokes to start" / "Log sessions to start") — and routes the remaining string-only surfaces through it.

Wired surfaces:
- `AchievementManager` streak descriptions ("3 days smoke-free" → templated)
- `NotificationHelper.showEncouragementNotification` — 24h / 72h / 1wk / 1mo / 3mo / 6mo / 1yr milestone copy
- `SmokelessWidget` — label ("SMOKE-FREE FOR") and empty-state CTA ("Log smokes to start")
- `HealthTimelineActivity.formatSmokeFreeLabel` — header label

Each callsite picks the primary substance from its own session query (`AchievementsActivity`, `SmokelessWidget`, `HealthTimelineActivity`) or reads `MainViewModel._primarySubstance` (notifications, via `checkMilestones`).

Also adds `.claude/` to `.gitignore` (session-local config).

## Still deferred (need substance-specific data, not just strings)
- `HealthBenefits` milestone text — cannabis physiology differs from tobacco's CO/nicotine pharmacokinetics
- Money-saved math — needs a cannabis cost model (not pack-priced)
- Long-form motivational copy with disease specifics ("heart disease", "lung cancer")
- Onboarding "cigarettes per day" baseline prompt — blocked on onboarding rewrite
- Settings cost-per-cigarette label — pairs with money-saved math

After this PR, ROADMAP §2.2 is structurally complete for the *string layer*. The next §2.2 cut needs onboarding to capture an explicit preferred substance and an alternate cost model.

## Test plan
- [ ] Log only cannabis sessions in the last 30 days → Achievements list shows "X days clean", widget shows "CLEAN FOR" / "Log sessions to start", Healing Timeline header shows "5d 12h clean"
- [ ] Reach the 24h smoke-free notification on cannabis primary → reads "You've been clean for 24 hours!"
- [ ] Switch back to tobacco-dominant → labels revert (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)