### PR TITLE
Add banked smoke-free time as additive lifetime counter

### DIFF
--- a/app/src/main/java/com/smokless/smokeless/MainActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/MainActivity.kt
@@ -32,11 +32,6 @@ import kotlin.math.min
 
 class MainActivity : AppCompatActivity() {
 
-    companion object {
-        private const val EXPOSURE_CIGARETTE_MS = 10L * 60 * 1000  // ~10 minutes
-        private const val EXPOSURE_WEED_MS = 30L * 60 * 1000       // ~30 minutes
-    }
-
     private lateinit var binding: ActivityMainBinding
     private val viewModel: MainViewModel by viewModels()
     
@@ -547,14 +542,14 @@ class MainActivity : AppCompatActivity() {
                 .setMessage("This will restart your countdown timer after the exposure time.")
                 .setPositiveButton("Cigarette (~10 min)") { _, _ ->
                     recordSmokeAction(
-                        EXPOSURE_CIGARETTE_MS,
+                        com.smokless.smokeless.data.entity.Substance.TOBACCO.exposureMs,
                         com.smokless.smokeless.data.entity.Substance.TOBACCO,
                     )
                 }
                 .setNegativeButton("Cancel", null)
                 .setNeutralButton("Weed (~30 min)") { _, _ ->
                     recordSmokeAction(
-                        EXPOSURE_WEED_MS,
+                        com.smokless.smokeless.data.entity.Substance.CANNABIS.exposureMs,
                         com.smokless.smokeless.data.entity.Substance.CANNABIS,
                     )
                 }
@@ -585,8 +580,16 @@ class MainActivity : AppCompatActivity() {
         viewModel.recordSmokeWithId(exposureOffsetMs, substance) { sessionId ->
             updateButtonState(0.0)
             updateWidgets()
+            // Lead with the banked counter (if any) so the moment of an honest
+            // log surfaces what the user kept, not what they reset.
+            val bankedMs = viewModel.bankedSmokeFreeMs.value ?: 0L
+            val message = if (bankedMs > 0L) {
+                "Logged. ${TimeFormatter.formatShort(bankedMs)} smoke-free banked — still yours."
+            } else {
+                "Smoke recorded"
+            }
             com.google.android.material.snackbar.Snackbar
-                .make(binding.root, "Smoke recorded", com.google.android.material.snackbar.Snackbar.LENGTH_LONG)
+                .make(binding.root, message, com.google.android.material.snackbar.Snackbar.LENGTH_LONG)
                 .setAction("UNDO") {
                     viewModel.undoSmoke(sessionId)
                     updateWidgets()
@@ -840,6 +843,11 @@ class MainActivity : AppCompatActivity() {
         // Observe money saved
         viewModel.moneySavedFormatted.observe(this) { formatted ->
             binding.sectionRecords.textMoneySaved.text = formatted
+        }
+
+        // Observe banked smoke-free time (lifetime, additive)
+        viewModel.bankedSmokeFreeMs.observe(this) { ms ->
+            binding.sectionRecords.textBankedHours.text = TimeFormatter.formatShort(ms)
         }
 
         // Observe reduction trend (data, no praise — per design note)

--- a/app/src/main/java/com/smokless/smokeless/data/entity/Substance.kt
+++ b/app/src/main/java/com/smokless/smokeless/data/entity/Substance.kt
@@ -8,9 +8,9 @@ package com.smokless.smokeless.data.entity
  * stays YAGNI-scoped to what the UI actually exposes today — tobacco and
  * cannabis.
  */
-enum class Substance {
-    TOBACCO,
-    CANNABIS;
+enum class Substance(val exposureMs: Long) {
+    TOBACCO(10L * 60 * 1000),
+    CANNABIS(30L * 60 * 1000);
 
     companion object {
         /** Default used by the Room migration backfill and any legacy code paths. */

--- a/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
@@ -93,6 +93,16 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val _reductionStats = MutableLiveData<ScoreCalculator.ReductionStats>()
     val reductionStats: LiveData<ScoreCalculator.ReductionStats> = _reductionStats
 
+    // Lifetime banked smoke-free time. Never resets on a slip — its job is to
+    // remove the perverse incentive to skip logging to preserve a streak.
+    private val _bankedSmokeFreeMs = MutableLiveData(0L)
+    val bankedSmokeFreeMs: LiveData<Long> = _bankedSmokeFreeMs
+
+    // Snapshot taken on each DB refresh so the per-second timer can tick the
+    // banked counter without touching the database.
+    private var firstSessionTimestamp = 0L
+    private var totalExposureMs = 0L
+
     // Dominant substance for headline copy. Drives unit nouns and the
     // "smoke-free / clean" labeling per ROADMAP §2.2.
     private val _primarySubstance = MutableLiveData(Substance.DEFAULT)
@@ -187,6 +197,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             val progress = ScoreCalculator.calculateIntervalProgress(timeSinceLastSmoke, target)
             _currentPercentage.postValue(progress)
         }
+
+        // Tick banked smoke-free counter using the snapshot from last refresh
+        if (firstSessionTimestamp > 0L) {
+            val banked = max(0L, System.currentTimeMillis() - firstSessionTimestamp - totalExposureMs)
+            _bankedSmokeFreeMs.postValue(banked)
+        }
     }
     
     /**
@@ -253,6 +269,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
         // Reduction trend — independent of selected period, uses all sessions
         _reductionStats.postValue(ScoreCalculator.calculateReductionStats(allSessions))
+
+        // Snapshot inputs for the banked-hours ticker; updateTimer() will
+        // recompute from these without re-querying the DB each second.
+        firstSessionTimestamp = if (allSessions.isEmpty()) 0L else allSessions.minOf { it.timestamp }
+        totalExposureMs = allSessions.sumOf { it.substance.exposureMs }
+        _bankedSmokeFreeMs.postValue(ScoreCalculator.calculateBankedSmokeFreeMs(allSessions))
 
         // Primary substance drives headline copy (units, clean label).
         val primary = SubstanceCopy.primarySubstance(allSessions)

--- a/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
@@ -481,6 +481,21 @@ object ScoreCalculator {
     }
 
     /**
+     * Lifetime smoke-free time, additive and never reset by a slip.
+     * = (now - first logged session) - sum of per-session exposure windows.
+     * Counterweight to clean-day streaks so honest logging doesn't cost the
+     * user their headline number.
+     */
+    fun calculateBankedSmokeFreeMs(sessions: List<SmokingSession>): Long {
+        if (sessions.isEmpty()) return 0L
+        val firstTimestamp = sessions.minOf { it.timestamp }
+        val now = System.currentTimeMillis()
+        val tracked = now - firstTimestamp
+        val exposure = sessions.sumOf { it.substance.exposureMs }
+        return max(0L, tracked - exposure)
+    }
+
+    /**
      * Calculate time since last cigarette
      */
     fun calculateTimeSinceLastSmoke(lastTimestamp: Long): Long {

--- a/app/src/main/res/layout/section_records.xml
+++ b/app/src/main/res/layout/section_records.xml
@@ -56,6 +56,65 @@
         android:orientation="vertical"
         android:visibility="gone">
 
+    <!-- Smoke-free time banked: lifetime, never-reset counter. Behavioral
+         counterweight to clean-day streaks so an honest log doesn't cost the
+         user their headline number. -->
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        app:cardBackgroundColor="@color/surface_card"
+        app:cardCornerRadius="22dp"
+        app:cardElevation="0dp"
+        app:strokeWidth="1dp"
+        app:strokeColor="@color/card_border_dim">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="20dp"
+            android:gravity="center"
+            android:minHeight="120dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="🏦"
+                android:textSize="36sp" />
+
+            <TextView
+                android:id="@+id/textBankedHours"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="0h"
+                android:textColor="@color/status_strong"
+                android:textSize="28sp"
+                android:fontFamily="sans-serif-black" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="Smoke-Free Time Banked"
+                android:textColor="@color/text_secondary"
+                android:textSize="12sp"
+                android:gravity="center" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="Yours to keep. A slip slows growth, never resets it."
+                android:textColor="@color/text_tertiary"
+                android:textSize="11sp"
+                android:gravity="center" />
+
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
## Summary
- Adds a lifetime, additive "Smoke-Free Time Banked" counter that grows monotonically and only slows (never resets) when a smoke is logged.
- Surfaces it as a card in the records section and in the post-smoke snackbar — the exact moment the user might otherwise feel they "lost" their streak.
- Behavioral aim: remove the perverse incentive to skip logging a slip to preserve a clean-day streak, so the app's data stays accurate.

## Implementation
- New `ScoreCalculator.calculateBankedSmokeFreeMs(sessions)` = `(now - firstTimestamp) - sum(exposureMs)`.
- Exposure constants moved onto the `Substance` enum (`TOBACCO.exposureMs`, `CANNABIS.exposureMs`); `MainActivity` reads from them instead of duplicating.
- `MainViewModel` snapshots `firstTimestamp` + `totalExposure` on each DB refresh, then ticks the counter per-second in `updateTimer()` without re-querying.

## Test plan
- [ ] Open the app — banked counter appears in records section, grows by the second.
- [ ] Log a smoke — snackbar shows "Logged. Xh smoke-free banked — still yours."
- [ ] Verify counter does **not** reset after the log (slowed growth only).
- [ ] Verify no regression in the countdown timer / streak / money-saved cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)