### PR TITLE
Detect verified craving victories and celebrate only confirmed wins

### DIFF
--- a/app/src/main/java/com/smokless/smokeless/MainActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/MainActivity.kt
@@ -68,6 +68,7 @@ class MainActivity : AppCompatActivity() {
         setupChipGroup()
         setupCharts()
         setupFab()
+        setupResistFab()
         setupCollapsibleSections()
         setupSwipeRefresh()
         observeViewModel()
@@ -653,23 +654,42 @@ class MainActivity : AppCompatActivity() {
     }
 
     /**
-     * Show confirmation when craving is resisted
+     * Show confirmation when a craving is logged. Warm but measured — the
+     * real celebration lands in [showVictorySnackbar] only after the 30-min
+     * window passes without a smoke, so this copy describes the *action* of
+     * naming the craving, not a guaranteed outcome.
      */
     private fun showResistConfirmation() {
-        // Create a simple snackbar/toast to encourage the user
         val messages = listOf(
-            "💪 Great job resisting!",
-            "🌟 You're stronger than you think!",
-            "🔥 That's the spirit!",
-            "💚 Your body thanks you!",
-            "⭐ Keep up the great work!",
-            "🎉 Victory over craving!",
-            "💎 Every resistance makes you stronger!"
+            "💚 Logged. Cravings usually pass in 3–5 minutes.",
+            "🌊 Riding it out. Breathe.",
+            "🌱 You named it. That's the first move.",
+            "✊ One thought at a time.",
+            "⏳ Let's see if it holds.",
         )
         val message = messages.random()
-        
+
         com.google.android.material.snackbar.Snackbar
             .make(binding.root, message, com.google.android.material.snackbar.Snackbar.LENGTH_SHORT)
+            .setBackgroundTint(ContextCompat.getColor(this, R.color.surface_elevated))
+            .setTextColor(ContextCompat.getColor(this, R.color.text_primary))
+            .show()
+    }
+
+    /**
+     * Earned celebration: shown only after the 30-min outcome window verified
+     * the craving did not lead to a smoke. Lands on the next app open after
+     * the window elapses, which is when the win is concrete and the user can
+     * actually feel it.
+     */
+    private fun showVictorySnackbar(count: Int) {
+        val message = if (count == 1) {
+            "🏅 1 craving held — verified smoke-free 30 min later."
+        } else {
+            "🏅 $count cravings held — verified smoke-free 30 min later."
+        }
+        com.google.android.material.snackbar.Snackbar
+            .make(binding.root, message, com.google.android.material.snackbar.Snackbar.LENGTH_LONG)
             .setBackgroundTint(ContextCompat.getColor(this, R.color.status_champion))
             .setTextColor(ContextCompat.getColor(this, R.color.white))
             .show()
@@ -848,6 +868,16 @@ class MainActivity : AppCompatActivity() {
         // Observe banked smoke-free time (lifetime, additive)
         viewModel.bankedSmokeFreeMs.observe(this) { ms ->
             binding.sectionRecords.textBankedHours.text = TimeFormatter.formatShort(ms)
+        }
+
+        // Surface verified craving victories: a craving counts here only
+        // after its 30-min window elapsed without a smoke. Stronger and more
+        // honest than the in-the-moment "I Resisted" tap.
+        viewModel.newCravingVictories.observe(this) { count ->
+            if (count > 0) {
+                showVictorySnackbar(count)
+                viewModel.dismissNewVictories()
+            }
         }
 
         // Observe reduction trend (data, no praise — per design note)

--- a/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
@@ -25,6 +25,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         private const val KEY_PACK_PRICE = "packPrice"
         private const val KEY_CIGS_PER_PACK = "cigsPerPack"
         private const val KEY_CURRENCY = "currency"
+        // Cursor for craving-victory detection: timestamp of the latest craving
+        // whose 30-min outcome window has been evaluated and acknowledged to
+        // the user. Initialized to "now" on first run so historical cravings
+        // don't all surface as victories at once.
+        private const val KEY_LAST_VICTORY_CURSOR = "lastVictoryCursorTs"
         private const val DEFAULT_PACK_PRICE = 10.0f
         private const val DEFAULT_CIGS_PER_PACK = 20
         private const val DEFAULT_CURRENCY = "$"
@@ -98,6 +103,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val _bankedSmokeFreeMs = MutableLiveData(0L)
     val bankedSmokeFreeMs: LiveData<Long> = _bankedSmokeFreeMs
 
+    // One-shot signal: number of cravings that verifiably held (no smoke
+    // within 30 min) since the last time the UI acknowledged them. Activity
+    // calls [dismissNewVictories] after showing.
+    private val _newCravingVictories = MutableLiveData(0)
+    val newCravingVictories: LiveData<Int> = _newCravingVictories
+
     // Snapshot taken on each DB refresh so the per-second timer can tick the
     // banked counter without touching the database.
     private var firstSessionTimestamp = 0L
@@ -166,14 +177,42 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         AppDatabase.databaseExecutor.execute {
             val timestamp = repository.getLastTimestamp()
             lastTimestamp = timestamp ?: 0L
-            
+
             // Calculate time since last smoke (for hero display)
             val score = ScoreCalculator.calculateTimeSinceLastSmoke(lastTimestamp)
             _currentScore.postValue(score)
-            
+
             // Calculate all period statistics
             calculateAllScores()
+
+            // Detect verified craving victories since last acknowledgement.
+            detectCravingVictories()
         }
+    }
+
+    private fun detectCravingVictories() {
+        var cursor = prefs.getLong(KEY_LAST_VICTORY_CURSOR, 0L)
+        if (cursor == 0L) {
+            // First run: anchor at "now" so historical cravings don't all
+            // surface at once. Their windows are already long-past, so this
+            // is a one-shot reset; future cravings will be evaluated normally.
+            cursor = System.currentTimeMillis()
+            prefs.edit().putLong(KEY_LAST_VICTORY_CURSOR, cursor).apply()
+            return
+        }
+        val cravings = repository.getAllCravings()
+        val sessions = repository.getAllSessionsSync()
+        val result = ScoreCalculator.detectCravingVictories(cravings, sessions, cursor)
+        if (result.newCursor != cursor) {
+            prefs.edit().putLong(KEY_LAST_VICTORY_CURSOR, result.newCursor).apply()
+        }
+        if (result.newCount > 0) {
+            _newCravingVictories.postValue(result.newCount)
+        }
+    }
+
+    fun dismissNewVictories() {
+        _newCravingVictories.value = 0
     }
     
     /**

--- a/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
@@ -1,5 +1,6 @@
 package com.smokless.smokeless.util
 
+import com.smokless.smokeless.data.entity.Craving
 import com.smokless.smokeless.data.entity.SmokingSession
 import java.text.SimpleDateFormat
 import java.util.*
@@ -478,6 +479,49 @@ object ScoreCalculator {
             velocityComparable = velocityComparable,
             loggedDaysLast7 = loggedLast7,
         )
+    }
+
+    /** Window after a craving log in which a smoke "cancels" the victory. */
+    const val CRAVING_VICTORY_WINDOW_MS = 30L * 60 * 1000
+
+    data class CravingVictories(
+        /** Number of confirmed victories beyond the cursor (verified: window elapsed, no smoke landed). */
+        val newCount: Int,
+        /** Updated cursor — advance past every craving whose window has fully elapsed, win or not. */
+        val newCursor: Long,
+    )
+
+    /**
+     * Detect craving victories: a logged craving counts when its 30-min window
+     * has fully elapsed AND no real smoke landed inside it. Smokes are matched
+     * against the actual smoke moment (timestamp minus the exposure offset
+     * already baked into [SmokingSession.timestamp]).
+     *
+     * Caller should initialize the cursor to "now" on first run to avoid
+     * surfacing a backlog of historical victories.
+     */
+    fun detectCravingVictories(
+        cravings: List<Craving>,
+        sessions: List<SmokingSession>,
+        cursor: Long,
+        nowMs: Long = System.currentTimeMillis(),
+    ): CravingVictories {
+        val confirmable = cravings.filter {
+            it.timestamp > cursor && nowMs - it.timestamp >= CRAVING_VICTORY_WINDOW_MS
+        }
+        if (confirmable.isEmpty()) return CravingVictories(0, cursor)
+        var victories = 0
+        var newCursor = cursor
+        for (craving in confirmable) {
+            val windowEnd = craving.timestamp + CRAVING_VICTORY_WINDOW_MS
+            val smokedWithin = sessions.any { s ->
+                val realSmokeTime = s.timestamp - s.substance.exposureMs
+                realSmokeTime in craving.timestamp..windowEnd
+            }
+            if (!smokedWithin) victories++
+            if (craving.timestamp > newCursor) newCursor = craving.timestamp
+        }
+        return CravingVictories(victories, newCursor)
     }
 
     /**

--- a/app/src/test/java/com/smokless/smokeless/util/ScoreCalculatorTest.kt
+++ b/app/src/test/java/com/smokless/smokeless/util/ScoreCalculatorTest.kt
@@ -1,5 +1,8 @@
 package com.smokless.smokeless.util
 
+import com.smokless.smokeless.data.entity.Craving
+import com.smokless.smokeless.data.entity.SmokingSession
+import com.smokless.smokeless.data.entity.Substance
 import org.junit.Assert.*
 import org.junit.Test
 
@@ -60,5 +63,50 @@ class ScoreCalculatorTest {
         val result = ScoreCalculator.calculateTimeSinceLastSmoke(oneHourAgo)
         assertTrue(result > 0)
         assertTrue(result in 3590_000L..3610_000L) // ~1 hour with tolerance
+    }
+
+    @Test
+    fun `detectCravingVictories counts only confirmed windows past the cursor`() {
+        val now = 10_000_000_000L
+        val hour = 3_600_000L
+        val cursor = now - 5 * hour
+        val cravings = listOf(
+            Craving(now - 6 * hour).apply { id = 1 }, // before cursor → ignored
+            Craving(now - 4 * hour).apply { id = 2 }, // past cursor, window elapsed → victory
+            Craving(now - 3 * hour).apply { id = 3 }, // past cursor, smoked within window → not a victory
+            Craving(now - 10 * 60 * 1000).apply { id = 4 }, // window not yet elapsed → not confirmable
+        )
+        val sessions = listOf(
+            // Real smoke at (now - 3h + 10min), exposure 10min → timestamp = now - 3h + 20min.
+            SmokingSession(now - 3 * hour + 20 * 60 * 1000, Substance.TOBACCO).apply { id = 1 },
+        )
+        val result = ScoreCalculator.detectCravingVictories(cravings, sessions, cursor, now)
+        assertEquals(1, result.newCount)
+        // Cursor advances past every craving whose window has fully elapsed (id 2 and 3),
+        // but NOT past id 4 (still within its 30-min window).
+        assertEquals(now - 3 * hour, result.newCursor)
+    }
+
+    @Test
+    fun `detectCravingVictories returns zero when nothing is confirmable yet`() {
+        val now = 10_000_000_000L
+        val cravings = listOf(Craving(now - 5 * 60 * 1000).apply { id = 1 })
+        val result = ScoreCalculator.detectCravingVictories(cravings, emptyList(), 0L, now)
+        assertEquals(0, result.newCount)
+        assertEquals(0L, result.newCursor)
+    }
+
+    @Test
+    fun `detectCravingVictories uses real smoke time accounting for exposure offset`() {
+        val now = 10_000_000_000L
+        val win = ScoreCalculator.CRAVING_VICTORY_WINDOW_MS
+        val craving = Craving(now - 2 * win).apply { id = 1 }
+        // Cannabis: 30 min exposure. Real smoke at craving - 5 min, timestamp = real + 30min,
+        // so the *stored* timestamp falls inside the window even though the smoke is outside.
+        val realSmoke = craving.timestamp - 5 * 60 * 1000
+        val session = SmokingSession(realSmoke + Substance.CANNABIS.exposureMs, Substance.CANNABIS).apply { id = 1 }
+        val result = ScoreCalculator.detectCravingVictories(listOf(craving), listOf(session), 0L, now)
+        // Real smoke landed BEFORE the craving → should count as a victory.
+        assertEquals(1, result.newCount)
     }
 }


### PR DESCRIPTION
## Summary
- Today the craving log fires the same generic praise on every "I Resisted" tap regardless of what happens next. Hollow praise erodes its own value.
- This adds outcome detection: a craving counts as a verified victory only after its 30-min window has elapsed without a smoke landing inside it (matched against real smoke time, not the exposure-shifted timestamp).
- On next app open, the user sees an honest "X cravings held — verified smoke-free 30 min later." snackbar. The in-the-moment "I Resisted" copy is retoned from guaranteed-victory to action-naming, so the earned celebration carries the real weight.
- Also fixes a pre-existing bug: `setupResistFab()` was defined but never called from `onCreate`, so tapping the I Resisted button did nothing.

## Implementation
- `ScoreCalculator.detectCravingVictories(cravings, sessions, cursor)` returns `(newCount, newCursor)`. Cursor in SharedPrefs advances past every confirmable craving (win or not) so we never double-count.
- First-run init: cursor anchored at `now` so a backlog of historical cravings doesn't fire a flood of victories.
- `MainViewModel.detectCravingVictories()` runs on every `refreshData()`. Activity observes `newCravingVictories` LiveData, shows the snackbar, then calls `dismissNewVictories()`.
- New unit tests cover cursor advancement, confirmable-only counting, and exposure-offset-aware smoke matching.

## Test plan
- [ ] Tap "I Resisted" — measured snackbar (e.g. "Cravings usually pass in 3–5 minutes") appears, the FAB now actually works.
- [ ] Wait > 30 min without logging a smoke, reopen the app — verified-victory snackbar shows.
- [ ] Log a craving then a smoke within 30 min, reopen later — no victory snackbar.
- [ ] First app open after install — no historical "victories" surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)