### PR TITLE
Add today's-pace indicator: one-glance "how am I doing right now"

### DIFF
--- a/app/src/main/java/com/smokless/smokeless/MainActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/MainActivity.kt
@@ -870,6 +870,9 @@ class MainActivity : AppCompatActivity() {
             binding.sectionRecords.textBankedHours.text = TimeFormatter.formatShort(ms)
         }
 
+        // Observe today-pace: one-glance "how am I doing right now" line
+        viewModel.todayPace.observe(this) { pace -> updateTodayPace(pace) }
+
         // Surface verified craving victories: a craving counts here only
         // after its 30-min window elapsed without a smoke. Stronger and more
         // honest than the in-the-moment "I Resisted" tap.
@@ -884,6 +887,27 @@ class MainActivity : AppCompatActivity() {
         viewModel.reductionStats.observe(this) { stats ->
             updateReductionTrend(stats)
         }
+    }
+
+    private fun updateTodayPace(pace: com.smokless.smokeless.util.ScoreCalculator.TodayPace) {
+        val typicalRounded = kotlin.math.round(pace.typicalByNow).toInt()
+        val unit = copy.unitFor(pace.actualToday.toLong())
+        val (text, colorRes) = when (pace.state) {
+            com.smokless.smokeless.util.ScoreCalculator.PaceState.CALIBRATING ->
+                "Keep logging — your pace verdict shows up after 3 days" to R.color.text_secondary
+            com.smokless.smokeless.util.ScoreCalculator.PaceState.AHEAD ->
+                "Ahead of pace — ${pace.actualToday} $unit today, usually $typicalRounded by now" to R.color.status_champion
+            com.smokless.smokeless.util.ScoreCalculator.PaceState.ON_PACE ->
+                "On pace — ${pace.actualToday} $unit today, usually $typicalRounded by now" to R.color.accent_amber
+            com.smokless.smokeless.util.ScoreCalculator.PaceState.BEHIND ->
+                "Behind pace — ${pace.actualToday} $unit today, usually $typicalRounded by now" to R.color.status_reset
+            com.smokless.smokeless.util.ScoreCalculator.PaceState.CLEAN_TODAY ->
+                "Matching your clean baseline — 0 today" to R.color.status_champion
+            com.smokless.smokeless.util.ScoreCalculator.PaceState.CLEAN_BREAK ->
+                "${pace.actualToday} $unit today — you've been clean lately, gentle reset" to R.color.accent_amber
+        }
+        binding.sectionHero.textTodayPace.text = text
+        binding.sectionHero.textTodayPace.setTextColor(ContextCompat.getColor(this, colorRes))
     }
 
     private fun updateReductionTrend(stats: com.smokless.smokeless.util.ScoreCalculator.ReductionStats) {

--- a/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
@@ -109,10 +109,21 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val _newCravingVictories = MutableLiveData(0)
     val newCravingVictories: LiveData<Int> = _newCravingVictories
 
+    // "How am I doing right now" — today vs typical pace, time-of-day aware.
+    private val _todayPace = MutableLiveData<ScoreCalculator.TodayPace>()
+    val todayPace: LiveData<ScoreCalculator.TodayPace> = _todayPace
+
     // Snapshot taken on each DB refresh so the per-second timer can tick the
     // banked counter without touching the database.
     private var firstSessionTimestamp = 0L
     private var totalExposureMs = 0L
+
+    // Snapshot inputs for the today-pace ticker so updateTimer can re-evaluate
+    // the pace verdict as the day progresses, without hitting the DB.
+    private var paceBaselineDailyAvg = 0.0
+    private var paceActualToday = 0
+    private var paceStartOfToday = 0L
+    private var paceHasBaseline = false
 
     // Dominant substance for headline copy. Drives unit nouns and the
     // "smoke-free / clean" labeling per ROADMAP §2.2.
@@ -242,6 +253,27 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             val banked = max(0L, System.currentTimeMillis() - firstSessionTimestamp - totalExposureMs)
             _bankedSmokeFreeMs.postValue(banked)
         }
+
+        // Re-evaluate today-pace verdict from the cached baseline. The day's
+        // expected count grows with elapsed time, so this can flip
+        // BEHIND → ON_PACE → AHEAD without a DB hit.
+        if (paceHasBaseline && paceStartOfToday > 0L) {
+            val nowMs = System.currentTimeMillis()
+            val dayMs = java.util.concurrent.TimeUnit.DAYS.toMillis(1)
+            val dayFraction = ((nowMs - paceStartOfToday).toDouble() / dayMs).coerceIn(0.0, 1.0)
+            val typicalByNow = paceBaselineDailyAvg * dayFraction
+            val state = when {
+                paceBaselineDailyAvg < 0.5 ->
+                    if (paceActualToday == 0) ScoreCalculator.PaceState.CLEAN_TODAY
+                    else ScoreCalculator.PaceState.CLEAN_BREAK
+                paceActualToday <= typicalByNow * 0.75 -> ScoreCalculator.PaceState.AHEAD
+                paceActualToday <= typicalByNow * 1.25 -> ScoreCalculator.PaceState.ON_PACE
+                else -> ScoreCalculator.PaceState.BEHIND
+            }
+            _todayPace.postValue(
+                ScoreCalculator.TodayPace(state, paceActualToday, typicalByNow, paceBaselineDailyAvg)
+            )
+        }
     }
     
     /**
@@ -314,6 +346,19 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         firstSessionTimestamp = if (allSessions.isEmpty()) 0L else allSessions.minOf { it.timestamp }
         totalExposureMs = allSessions.sumOf { it.substance.exposureMs }
         _bankedSmokeFreeMs.postValue(ScoreCalculator.calculateBankedSmokeFreeMs(allSessions))
+
+        // Snapshot today-pace inputs so the per-second tick can re-evaluate
+        // the verdict as the day's expected count grows.
+        val pace = ScoreCalculator.calculateTodayPace(allSessions)
+        _todayPace.postValue(pace)
+        paceBaselineDailyAvg = pace.baselineDailyAvg
+        paceActualToday = pace.actualToday
+        paceHasBaseline = pace.state != ScoreCalculator.PaceState.CALIBRATING
+        val cal = Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
+        }
+        paceStartOfToday = cal.timeInMillis
 
         // Primary substance drives headline copy (units, clean label).
         val primary = SubstanceCopy.primarySubstance(allSessions)

--- a/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
@@ -484,6 +484,66 @@ object ScoreCalculator {
     /** Window after a craving log in which a smoke "cancels" the victory. */
     const val CRAVING_VICTORY_WINDOW_MS = 30L * 60 * 1000
 
+    /** "How am I doing right now" — one-glance verdict for today vs typical pace. */
+    enum class PaceState {
+        CALIBRATING, // not enough history to compare against
+        AHEAD,       // notably below typical-by-now
+        ON_PACE,     // within ±25% of typical-by-now
+        BEHIND,      // notably above typical-by-now
+        CLEAN_TODAY, // baseline is near-zero and today is also clean
+        CLEAN_BREAK, // baseline is near-zero but smoked today
+    }
+
+    data class TodayPace(
+        val state: PaceState,
+        val actualToday: Int,
+        val typicalByNow: Double,
+        val baselineDailyAvg: Double,
+    )
+
+    /**
+     * Compute today's pace against a rolling 14-day baseline, time-of-day
+     * aware: typical-by-now scales with the fraction of the day elapsed. The
+     * baseline excludes today (so a heavy morning doesn't reset its own bar).
+     * Requires at least 3 prior days of tracking — fewer than that and we
+     * return CALIBRATING rather than a misleading verdict.
+     */
+    fun calculateTodayPace(
+        allSessions: List<SmokingSession>,
+        nowMs: Long = System.currentTimeMillis(),
+    ): TodayPace {
+        if (allSessions.isEmpty()) return TodayPace(PaceState.CALIBRATING, 0, 0.0, 0.0)
+
+        val cal = Calendar.getInstance().apply {
+            timeInMillis = nowMs
+            set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
+        }
+        val startOfToday = cal.timeInMillis
+        val actualToday = allSessions.count { it.timestamp >= startOfToday }
+
+        val day = TimeUnit.DAYS.toMillis(1)
+        val firstSession = allSessions.minOf { it.timestamp }
+        val trackedDays = ((nowMs - firstSession) / day).toInt() + 1
+        val priorDays = (trackedDays - 1).coerceAtMost(14)
+        if (priorDays < 3) return TodayPace(PaceState.CALIBRATING, actualToday, 0.0, 0.0)
+
+        val priorStart = startOfToday - priorDays * day
+        val priorCount = allSessions.count { it.timestamp in priorStart until startOfToday }
+        val baselineDailyAvg = priorCount.toDouble() / priorDays
+
+        val dayFraction = ((nowMs - startOfToday).toDouble() / day).coerceIn(0.0, 1.0)
+        val typicalByNow = baselineDailyAvg * dayFraction
+
+        val state = when {
+            baselineDailyAvg < 0.5 -> if (actualToday == 0) PaceState.CLEAN_TODAY else PaceState.CLEAN_BREAK
+            actualToday <= typicalByNow * 0.75 -> PaceState.AHEAD
+            actualToday <= typicalByNow * 1.25 -> PaceState.ON_PACE
+            else -> PaceState.BEHIND
+        }
+        return TodayPace(state, actualToday, typicalByNow, baselineDailyAvg)
+    }
+
     data class CravingVictories(
         /** Number of confirmed victories beyond the cursor (verified: window elapsed, no smoke landed). */
         val newCount: Int,

--- a/app/src/main/res/layout/section_hero.xml
+++ b/app/src/main/res/layout/section_hero.xml
@@ -149,12 +149,29 @@
                 android:fontFamily="sans-serif"
                 android:gravity="center" />
 
+            <!-- Today's pace: glanceable "how am I doing right now" verdict. -->
+            <TextView
+                android:id="@+id/textTodayPace"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:paddingHorizontal="16dp"
+                android:paddingVertical="12dp"
+                android:background="@drawable/bg_stat_chip"
+                android:text="Keep logging — your pace shows up after 3 days"
+                android:textColor="@color/text_secondary"
+                android:textSize="13sp"
+                android:fontFamily="sans-serif-medium"
+                android:gravity="center"
+                android:contentDescription="Today's pace versus your typical pace"
+                android:accessibilityLiveRegion="polite" />
+
             <!-- Goal Progress Section -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                android:layout_marginTop="28dp"
+                android:layout_marginTop="12dp"
                 android:background="@drawable/bg_stat_chip"
                 android:padding="18dp">
 

--- a/app/src/test/java/com/smokless/smokeless/util/ScoreCalculatorTest.kt
+++ b/app/src/test/java/com/smokless/smokeless/util/ScoreCalculatorTest.kt
@@ -97,6 +97,90 @@ class ScoreCalculatorTest {
     }
 
     @Test
+    fun `calculateTodayPace returns CALIBRATING with no history`() {
+        val pace = ScoreCalculator.calculateTodayPace(emptyList())
+        assertEquals(ScoreCalculator.PaceState.CALIBRATING, pace.state)
+    }
+
+    @Test
+    fun `calculateTodayPace returns CALIBRATING with fewer than 3 prior days`() {
+        // Pick a "now" deep into the day so dayFraction is meaningful.
+        val now = paceNow(hourOfDay = 18)
+        val day = 24L * 3_600_000
+        // Two prior days of activity, plus today: priorDays = 2 < 3.
+        val sessions = listOf(
+            SmokingSession(now - 2 * day).apply { id = 1 },
+            SmokingSession(now - 1 * day).apply { id = 2 },
+            SmokingSession(now - 3_600_000).apply { id = 3 }, // today
+        )
+        val pace = ScoreCalculator.calculateTodayPace(sessions, now)
+        assertEquals(ScoreCalculator.PaceState.CALIBRATING, pace.state)
+        assertEquals(1, pace.actualToday)
+    }
+
+    @Test
+    fun `calculateTodayPace AHEAD when today smoked below 75 percent of typical-by-now`() {
+        val now = paceNow(hourOfDay = 18) // 18/24 = 0.75 of day elapsed
+        val day = 24L * 3_600_000
+        // 7 prior days, ~10 sessions/day → baseline 10. At 18:00 typical ≈ 7.5.
+        // Today: 4 sessions → 4 / 7.5 = 0.53, below 75% → AHEAD.
+        val priors = (1..7).flatMap { d ->
+            List(10) { SmokingSession(now - d * day - it * 60_000L).apply { id = (d * 100 + it).toLong() } }
+        }
+        val today = List(4) { SmokingSession(now - it * 60_000L - 7_200_000).apply { id = (1000 + it).toLong() } }
+        val pace = ScoreCalculator.calculateTodayPace(priors + today, now)
+        assertEquals(ScoreCalculator.PaceState.AHEAD, pace.state)
+        assertEquals(4, pace.actualToday)
+    }
+
+    @Test
+    fun `calculateTodayPace BEHIND when today smoked above 125 percent of typical-by-now`() {
+        val now = paceNow(hourOfDay = 12) // 12/24 = 0.5
+        val day = 24L * 3_600_000
+        // 7 prior days, 10/day → baseline 10. At noon typical ≈ 5.
+        // Today: 8 → 8/5 = 1.6, above 125% → BEHIND.
+        val priors = (1..7).flatMap { d ->
+            List(10) { SmokingSession(now - d * day - it * 60_000L).apply { id = (d * 100 + it).toLong() } }
+        }
+        val today = List(8) { SmokingSession(now - it * 60_000L - 3_600_000).apply { id = (2000 + it).toLong() } }
+        val pace = ScoreCalculator.calculateTodayPace(priors + today, now)
+        assertEquals(ScoreCalculator.PaceState.BEHIND, pace.state)
+    }
+
+    @Test
+    fun `calculateTodayPace CLEAN_BREAK when baseline near zero but smoked today`() {
+        val now = paceNow(hourOfDay = 15)
+        val day = 24L * 3_600_000
+        // 7 prior clean days (just one early session for tracking-length, then nothing in window)
+        val priors = listOf(SmokingSession(now - 8 * day).apply { id = 1 })
+        val today = listOf(SmokingSession(now - 60_000L).apply { id = 2 })
+        val pace = ScoreCalculator.calculateTodayPace(priors + today, now)
+        assertEquals(ScoreCalculator.PaceState.CLEAN_BREAK, pace.state)
+        assertEquals(1, pace.actualToday)
+    }
+
+    @Test
+    fun `calculateTodayPace CLEAN_TODAY when baseline near zero and today is clean`() {
+        val now = paceNow(hourOfDay = 15)
+        val day = 24L * 3_600_000
+        val priors = listOf(SmokingSession(now - 8 * day).apply { id = 1 })
+        val pace = ScoreCalculator.calculateTodayPace(priors, now)
+        assertEquals(ScoreCalculator.PaceState.CLEAN_TODAY, pace.state)
+        assertEquals(0, pace.actualToday)
+    }
+
+    /** Returns a deterministic "now" at a fixed hour of day, avoiding clock flakiness. */
+    private fun paceNow(hourOfDay: Int): Long {
+        val cal = java.util.Calendar.getInstance().apply {
+            set(java.util.Calendar.YEAR, 2026); set(java.util.Calendar.MONTH, 4) // May
+            set(java.util.Calendar.DAY_OF_MONTH, 15)
+            set(java.util.Calendar.HOUR_OF_DAY, hourOfDay)
+            set(java.util.Calendar.MINUTE, 0); set(java.util.Calendar.SECOND, 0); set(java.util.Calendar.MILLISECOND, 0)
+        }
+        return cal.timeInMillis
+    }
+
+    @Test
     fun `detectCravingVictories uses real smoke time accounting for exposure offset`() {
         val now = 10_000_000_000L
         val win = ScoreCalculator.CRAVING_VICTORY_WINDOW_MS


### PR DESCRIPTION
## Summary
- The hero screen has many numbers (timer, percentage, streak, count, 30-day velocity) but none answer "am I doing well *right now*?"
- Adds a single color-coded line in the hero, above the goal-progress block: *"Ahead of pace — 2 today, usually 4 by now"*.
- Time-of-day aware: the "usually by now" figure scales with the fraction of today elapsed, so a heavy morning doesn't read the same as a heavy evening.

## States
- **AHEAD** (green) — today < 75% of typical-by-now
- **ON_PACE** (amber) — within ±25% of typical-by-now
- **BEHIND** (red) — today > 125% of typical-by-now
- **CLEAN_TODAY / CLEAN_BREAK** — when baseline is near-zero
- **CALIBRATING** — first 3 days, before there's enough history for a non-misleading verdict

## Implementation
- `ScoreCalculator.calculateTodayPace(sessions, nowMs)` returns `TodayPace(state, actualToday, typicalByNow, baselineDailyAvg)`. Baseline = rolling 14-day daily average, excluding today.
- `MainViewModel` snapshots baseline + actual-today + start-of-today on each refresh; `updateTimer()` re-evaluates the verdict from cache each second so it can flip live as the day's expected count grows.
- Unit tests cover CALIBRATING (no history, < 3 days), AHEAD, BEHIND, CLEAN_TODAY, and CLEAN_BREAK using a deterministic clock to avoid flakiness.

## Test plan
- [ ] Brand-new install → "Keep logging — your pace verdict shows up after 3 days".
- [ ] After 3+ days of history, line reads in matching color based on today's count vs typical.
- [ ] Verdict updates as the day progresses (e.g. flips from BEHIND to ON_PACE at typical pace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)