### PR TITLE
feat(bios): surface pending-approval state in settings

### DIFF
--- a/app/src/main/java/com/smokless/smokeless/SettingsActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/SettingsActivity.kt
@@ -57,6 +57,37 @@ class SettingsActivity : AppCompatActivity() {
         binding.btnSyncBiosHistory.setOnClickListener {
             confirmBackfill()
         }
+        binding.btnOpenBiosCompanions.setOnClickListener {
+            launchBiosCompanions()
+        }
+    }
+
+    /**
+     * Launches Bios's main activity with the deep-link extra it reads to
+     * jump straight into Settings → Companion Apps. Used by the pending-
+     * approval banner so the user is one tap from approving Smokeless.
+     */
+    private fun launchBiosCompanions() {
+        val intent = packageManager.getLaunchIntentForPackage(BiosClient.BIOS_PACKAGE)
+        if (intent == null) {
+            Snackbar.make(
+                binding.root,
+                "Bios isn't installed on this device.",
+                Snackbar.LENGTH_SHORT,
+            ).show()
+            return
+        }
+        intent.putExtra(BiosClient.BIOS_EXTRA_NAVIGATE_TO_COMPANIONS, true)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        try {
+            startActivity(intent)
+        } catch (_: Exception) {
+            Snackbar.make(
+                binding.root,
+                "Couldn't open Bios — try opening it manually and check Settings → Companion Apps.",
+                Snackbar.LENGTH_LONG,
+            ).show()
+        }
     }
 
     private fun confirmBackfill() {
@@ -387,15 +418,40 @@ class SettingsActivity : AppCompatActivity() {
         }
 
         viewModel.biosStatus.observe(this) { status ->
-            binding.textBiosStatus.text = when (status) {
-                BiosClient.Status.CONNECTED -> "Connected to Bios"
-                BiosClient.Status.NOT_ENABLED -> "Not enabled"
-                else -> "Bios not installed"
-            }
-            binding.switchBiosIntegration.isEnabled = status == BiosClient.Status.CONNECTED ||
-                status == BiosClient.Status.NOT_ENABLED
-            binding.btnSyncBiosHistory.isEnabled = status == BiosClient.Status.CONNECTED
+            updateBiosStatusViews(status, viewModel.biosLastPushOutcome.value)
         }
+
+        viewModel.biosLastPushOutcome.observe(this) { outcome ->
+            updateBiosStatusViews(viewModel.biosStatus.value, outcome)
+        }
+    }
+
+    /**
+     * Joint render of [BiosClient.Status] + [BiosClient.LastPushOutcome].
+     * Status alone says whether the integration is wired; the outcome
+     * adds the post-write state — specifically the *pending approval*
+     * case, which is the most common reason an enabled integration
+     * isn't actually flowing data.
+     */
+    private fun updateBiosStatusViews(
+        status: BiosClient.Status?,
+        outcome: BiosClient.LastPushOutcome?,
+    ) {
+        val pending = status == BiosClient.Status.CONNECTED &&
+            outcome == BiosClient.LastPushOutcome.PENDING_APPROVAL
+        binding.textBiosStatus.text = when {
+            pending -> "Waiting for approval in Bios"
+            status == BiosClient.Status.CONNECTED &&
+                outcome == BiosClient.LastPushOutcome.OK -> "Connected to Bios"
+            status == BiosClient.Status.CONNECTED -> "Connected to Bios"
+            status == BiosClient.Status.NOT_ENABLED -> "Not enabled"
+            else -> "Bios not installed"
+        }
+        binding.switchBiosIntegration.isEnabled = status == BiosClient.Status.CONNECTED ||
+            status == BiosClient.Status.NOT_ENABLED
+        binding.btnSyncBiosHistory.isEnabled = status == BiosClient.Status.CONNECTED
+        binding.biosPendingApprovalBanner.visibility =
+            if (pending) android.view.View.VISIBLE else android.view.View.GONE
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/smokless/smokeless/bios/BiosClient.kt
+++ b/app/src/main/java/com/smokless/smokeless/bios/BiosClient.kt
@@ -45,6 +45,25 @@ class BiosClient(private val context: Context) {
         else -> Status.CONNECTED
     }
 
+    /**
+     * Outcome of the most recent push attempt. Persisted so the settings UI
+     * can surface actionable guidance — particularly the
+     * [LastPushOutcome.PENDING_APPROVAL] state, which is the first-write
+     * response from Bios's CompanionGate (the owner has to approve
+     * Smokeless inside Bios → Settings → Companion Apps before any data
+     * lands). Without surfacing this, the user logs an event, sees nothing
+     * in Bios, and has no signal that the integration is one approval tap
+     * away from working.
+     */
+    val lastPushOutcome: LastPushOutcome
+        get() = prefs.getString(KEY_LAST_PUSH_OUTCOME, null)
+            ?.let { runCatching { LastPushOutcome.valueOf(it) }.getOrNull() }
+            ?: LastPushOutcome.NEVER_TRIED
+
+    private fun recordOutcome(outcome: LastPushOutcome) {
+        prefs.edit().putString(KEY_LAST_PUSH_OUTCOME, outcome.name).apply()
+    }
+
     fun pushSmokingEvent(timestamp: Long, substance: Substance) =
         push(useMetricFor(substance), timestamp)
 
@@ -88,11 +107,24 @@ class BiosClient(private val context: Context) {
         }
         return try {
             context.contentResolver.insert(uri, values)
+            recordOutcome(LastPushOutcome.OK)
             true
         } catch (e: SecurityException) {
-            Log.d(TAG, "Bios rejected $metricType: ${e.message}")
+            val msg = e.message.orEmpty()
+            // Bios's CompanionGate throws this exact message on first
+            // contact from a new package. Distinguish it from the
+            // post-revoke / cert-pin failures so the UI can guide the
+            // user to the approval tap instead of a generic error.
+            val outcome = if (msg.contains("not approved", ignoreCase = true)) {
+                LastPushOutcome.PENDING_APPROVAL
+            } else {
+                LastPushOutcome.OTHER_FAILURE
+            }
+            recordOutcome(outcome)
+            Log.d(TAG, "Bios rejected $metricType: $msg (outcome=$outcome)")
             false
         } catch (e: Exception) {
+            recordOutcome(LastPushOutcome.OTHER_FAILURE)
             Log.d(TAG, "Bios push failed for $metricType: ${e.message}")
             false
         }
@@ -100,12 +132,43 @@ class BiosClient(private val context: Context) {
 
     enum class Status { NOT_INSTALLED, NOT_ENABLED, CONNECTED }
 
+    /**
+     * What happened the last time Smokeless tried to write to Bios.
+     * Persisted across restarts so the settings screen can render a
+     * meaningful state on cold open.
+     */
+    enum class LastPushOutcome {
+        /** No push attempted yet (fresh install or integration just toggled on). */
+        NEVER_TRIED,
+
+        /** Last push landed. The integration is fully wired. */
+        OK,
+
+        /** Bios's CompanionGate rejected the write because the owner has
+         *  not yet approved Smokeless in Bios → Settings → Companion Apps. */
+        PENDING_APPROVAL,
+
+        /** Bios rejected the write for some other reason — most often a
+         *  paired-release mismatch (Bios doesn't yet whitelist a key
+         *  Smokeless writes). */
+        OTHER_FAILURE,
+    }
+
     data class BackfillResult(val pushed: Int, val failed: Int, val total: Int)
 
     companion object {
         private const val TAG = "BiosClient"
         private const val PREFS_NAME = "SmokelessPrefs"
         private const val KEY_ENABLED = "biosIntegrationEnabled"
+        private const val KEY_LAST_PUSH_OUTCOME = "biosLastPushOutcome"
+
+        /** Bios's `MainActivity` reads this extra to deep-link directly
+         *  into Settings → Companion Apps. Mirrors
+         *  `CompanionAccessNotifier.EXTRA_NAVIGATE_TO_COMPANIONS` in
+         *  Bios; pinned by string here because Smokeless doesn't depend
+         *  on Bios's source. */
+        const val BIOS_PACKAGE = "com.bios.app"
+        const val BIOS_EXTRA_NAVIGATE_TO_COMPANIONS = "navigate_to_companions"
 
         const val METRIC_TOBACCO_USE = "tobacco_use"
         const val METRIC_TOBACCO_CRAVING = "tobacco_craving"

--- a/app/src/main/java/com/smokless/smokeless/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/smokless/smokeless/ui/settings/SettingsViewModel.kt
@@ -61,6 +61,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     private val _biosStatus = MutableLiveData<BiosClient.Status>()
     val biosStatus: LiveData<BiosClient.Status> = _biosStatus
 
+    private val _biosLastPushOutcome = MutableLiveData<BiosClient.LastPushOutcome>()
+    val biosLastPushOutcome: LiveData<BiosClient.LastPushOutcome> = _biosLastPushOutcome
+
     init {
         loadSettings()
     }
@@ -79,6 +82,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         _currency.value = currencySymbol
         _biosEnabled.value = biosClient.isEnabled
         _biosStatus.value = biosClient.status()
+        _biosLastPushOutcome.value = biosClient.lastPushOutcome
         updateDescriptions(isStrict, level)
     }
 
@@ -86,10 +90,12 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         biosClient.setEnabled(enabled)
         _biosEnabled.value = enabled
         _biosStatus.value = biosClient.status()
+        _biosLastPushOutcome.value = biosClient.lastPushOutcome
     }
 
     fun refreshBiosStatus() {
         _biosStatus.value = biosClient.status()
+        _biosLastPushOutcome.value = biosClient.lastPushOutcome
     }
     
     fun setStrictMode(enabled: Boolean) {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -587,6 +587,47 @@
                         app:icon="@drawable/ic_upload"
                         app:iconGravity="textStart" />
 
+                    <!-- Pending-approval banner. Visible only when Bios
+                         rejected the last push with "Companion not
+                         approved by owner" — guides the user to the
+                         approval tap inside Bios. -->
+                    <LinearLayout
+                        android:id="@+id/biosPendingApprovalBanner"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="16dp"
+                        android:orientation="vertical"
+                        android:padding="12dp"
+                        android:background="@color/surface_card"
+                        android:visibility="gone">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Waiting for approval in Bios"
+                            android:textColor="@color/text_primary"
+                            android:textSize="14sp"
+                            android:fontFamily="sans-serif-medium" />
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="4dp"
+                            android:text="Bios received your push but is waiting for you to approve Smokeless in its Companion Apps list. Approve once and future events will flow through automatically."
+                            android:textColor="@color/text_secondary"
+                            android:textSize="13sp"
+                            android:lineSpacingExtra="2dp" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnOpenBiosCompanions"
+                            style="@style/Widget.Material3.Button.TonalButton"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="12dp"
+                            android:text="Open Bios → Companion Apps" />
+
+                    </LinearLayout>
+
                 </LinearLayout>
 
             </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary

Real-world bug from a user smoke test: enabled the Bios integration in Smokeless settings, logged a cannabis event, opened the Bios Active Substances dashboard, saw nothing. Reason: Bios's `CompanionGate` rejects the first write from a never-seen-before package with `SecurityException("Companion not approved by owner")` until the owner explicitly approves Smokeless inside Bios → Settings → Companion Apps. Smokeless's `BiosClient.push()` logged the rejection and stayed silent, so the user had no signal that the integration was one approval tap away from working.

This PR makes that state visible.

- **`BiosClient`** gains a `LastPushOutcome` enum (`NEVER_TRIED` / `OK` / `PENDING_APPROVAL` / `OTHER_FAILURE`) persisted in `SharedPreferences`. `push()` inspects the `SecurityException` message to distinguish the pending-approval case from generic rejections.
- **`SettingsViewModel`** exposes `biosLastPushOutcome: LiveData<BiosClient.LastPushOutcome>`. Both `loadSettings()` and `refreshBiosStatus()` reload it, so re-entering Settings (which already calls `refreshBiosStatus()` in `onResume`) picks up post-write outcomes immediately.
- **`activity_settings.xml`** gains a "Waiting for approval in Bios" banner (hidden by default) with explanatory copy and an **Open Bios → Companion Apps** CTA.
- **`SettingsActivity`** observes both `biosStatus` and `biosLastPushOutcome`, joining them in `updateBiosStatusViews()`. When status is `CONNECTED` and outcome is `PENDING_APPROVAL`, the status text reads *"Waiting for approval in Bios"* and the banner becomes visible. The CTA launches Bios's main activity with the `navigate_to_companions` extra Bios reads to jump straight into Companion Apps.

Bios package and deep-link extra are pinned as string constants in `BiosClient.companion` (`BIOS_PACKAGE`, `BIOS_EXTRA_NAVIGATE_TO_COMPANIONS`) so Smokeless stays free of a compile-time dependency on Bios source.

## Test plan

- [x] `./gradlew assembleDebug` — clean.
- [x] `./gradlew testDebugUnitTest --rerun-tasks` — all existing tests green.
- [ ] Live UI smoke (recommended): toggle Bios integration on, log a smoking/cannabis event, open Settings — the banner should show with the *"Waiting for approval in Bios"* status; tap the CTA, approve Smokeless inside Bios, log another event, reopen Settings — status should flip to *"Connected to Bios"* with the banner hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)