### PR TITLE
feat: pending-approval banner + signed APK release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: Release APK
+
+# Trigger: push a tag like v1.2.3
+# Builds a signed release APK and attaches it (plus SHA-256) to a GitHub Release.
+#
+# Per-repo customisation: set WORKING_DIR below.
+#   - `.`        for repos with gradle at root  (Smokeless, SoulRadio, W2F)
+#   - `android`  for repos with gradle nested   (Bios, Fil, Virgil)
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v1.2.3)'
+        required: true
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  WORKING_DIR: .
+
+jobs:
+  build:
+    name: Build signed APK
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-
+
+      - name: Decode keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            echo "::error::RELEASE_KEYSTORE_BASE64 secret is not set. See templates/android-release/README.md."
+            exit 1
+          fi
+          echo "$KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release.keystore"
+          echo "RELEASE_KEYSTORE_PATH=$RUNNER_TEMP/release.keystore" >> "$GITHUB_ENV"
+
+      - name: Assemble release APK
+        working-directory: ${{ env.WORKING_DIR }}
+        env:
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: ./gradlew assembleRelease --no-daemon
+
+      - name: Locate APK
+        id: find_apk
+        run: |
+          APK="$(find "${{ env.WORKING_DIR }}/app/build/outputs/apk/release" -name '*.apk' | head -n1)"
+          if [ -z "$APK" ]; then
+            echo "::error::No release APK found."
+            exit 1
+          fi
+          TAG="${GITHUB_REF#refs/tags/}"
+          [ "$TAG" = "$GITHUB_REF" ] && TAG="${{ github.event.inputs.tag }}"
+          REPO="${GITHUB_REPOSITORY##*/}"
+          OUT="${REPO}-${TAG}.apk"
+          cp "$APK" "$OUT"
+          sha256sum "$OUT" > "${OUT}.sha256"
+          echo "apk=$OUT" >> "$GITHUB_OUTPUT"
+          echo "sha=${OUT}.sha256" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-apk
+          path: |
+            ${{ steps.find_apk.outputs.apk }}
+            ${{ steps.find_apk.outputs.sha }}
+          retention-days: 30
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.find_apk.outputs.tag }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            ${{ steps.find_apk.outputs.apk }}
+            ${{ steps.find_apk.outputs.sha }}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,10 +12,22 @@ android {
         applicationId "com.smokless.smokeless"
         minSdk 26
         targetSdk 34
-        versionCode 4
-        versionName "3.0"
+        versionCode 5
+        versionName "3.0.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    signingConfigs {
+        release {
+            def keystorePath = System.getenv("RELEASE_KEYSTORE_PATH")
+            if (keystorePath) {
+                storeFile = file(keystorePath)
+                storePassword = System.getenv("RELEASE_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("RELEASE_KEY_ALIAS")
+                keyPassword = System.getenv("RELEASE_KEY_PASSWORD")
+            }
+        }
     }
 
     buildTypes {
@@ -23,6 +35,9 @@ android {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig = System.getenv("RELEASE_KEYSTORE_PATH") \
+                ? signingConfigs.release \
+                : signingConfigs.debug
         }
     }
     


### PR DESCRIPTION
## Summary
- Surface Bios pending-approval state in Smokeless settings
- Add tag-driven release pipeline: signed APK on \`v*\` push, attached to GitHub Release with SHA-256
- Env-driven signing config in \`app/build.gradle\` (debug fallback when keystore env unset)
- Bump version 3.0 → 3.0.1 (versionCode 4 → 5) for first public release

## Test plan
- [x] \`./gradlew tasks\` parses build.gradle clean
- [ ] Tag \`v3.0.1\` from master triggers release workflow
- [ ] Workflow produces signed APK, SHA-256, GitHub Release
- [ ] APK installs on a real device

🤖 Generated with [Claude Code](https://claude.com/claude-code)