### PR TITLE
Anchor first-smoke-of-day at Bios wake-time

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <uses-permission android:name="com.bios.app.permission.WRITE_COMPANION" />
+    <uses-permission android:name="com.bios.app.permission.READ_HEALTH" />
 
     <queries>
         <package android:name="com.bios.app" />

--- a/app/src/main/java/com/smokless/smokeless/MainActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/MainActivity.kt
@@ -33,7 +33,6 @@ import com.smokless.smokeless.util.ScoreCalculator
 import com.smokless.smokeless.util.SubstanceCopy
 import com.smokless.smokeless.util.TimeFormatter
 import java.text.DecimalFormat
-import java.util.concurrent.TimeUnit
 import kotlin.math.min
 import kotlin.math.roundToInt
 
@@ -860,7 +859,7 @@ class MainActivity : AppCompatActivity() {
         cleanDays.text = "${digest.cleanDaysThisWeek}/7"
 
         val longestMs = digest.longestStretchMs
-        val longestHours = longestMs / java.util.concurrent.TimeUnit.HOURS.toMillis(1)
+        val longestHours = longestMs / 3_600_000L
         longest.text = when {
             longestHours >= 24 -> "${longestHours / 24}d"
             longestHours >= 1 -> "${longestHours}h"
@@ -1094,22 +1093,20 @@ class MainActivity : AppCompatActivity() {
         val text = binding.sectionProgression.root.findViewById<android.widget.TextView>(
             R.id.textFirstSmoke
         )
-        if (fs.typicalFirstHour == null && fs.todayFirstMsFromStartOfDay == null) {
+        if (fs.typicalFirstHour == null && fs.todayFirstClockHour == null) {
             text.text = "Log a few mornings to compare today against your usual."
             text.setTextColor(ContextCompat.getColor(this, R.color.text_secondary))
             return
         }
         val typicalText = fs.typicalFirstHour?.let { "typically ${formatHourOfDay(it)}" }
 
-        if (fs.todayFirstMsFromStartOfDay == null) {
+        if (fs.todayFirstClockHour == null) {
             val typ = typicalText ?: "no typical time yet"
             text.text = "Haven't smoked yet today — $typ."
             text.setTextColor(ContextCompat.getColor(this, R.color.status_champion))
             return
         }
-        val todayHourFloat =
-            fs.todayFirstMsFromStartOfDay.toDouble() / TimeUnit.HOURS.toMillis(1)
-        val todayText = "First smoke at ${formatHourOfDay(todayHourFloat)}"
+        val todayText = "First smoke at ${formatHourOfDay(fs.todayFirstClockHour)}"
         val delta = fs.deltaMinutes
         val combined = when {
             delta == null -> "$todayText."

--- a/app/src/main/java/com/smokless/smokeless/bios/BiosClient.kt
+++ b/app/src/main/java/com/smokless/smokeless/bios/BiosClient.kt
@@ -64,6 +64,54 @@ class BiosClient(private val context: Context) {
         prefs.edit().putString(KEY_LAST_PUSH_OUTCOME, outcome.name).apply()
     }
 
+    /**
+     * Most recent wake-up time according to Bios, or null if unavailable.
+     *
+     * Wake-up is read from the latest `sleep_duration` row in the last 24h:
+     * Bios writes that row's `timestamp` to the *end* of the sleep session
+     * (HealthConnectAdapter.kt:284), so the latest such row is "when the user
+     * last got up." Used to anchor Smokeless's "first smoke of the day"
+     * computation at wake-time instead of calendar midnight — a 00:15 smoke
+     * is then correctly the previous waking day's *last*, not the next day's
+     * first.
+     *
+     * Silent failure modes (all return null, caller falls back to midnight):
+     *  - Bios not installed
+     *  - READ_HEALTH not granted, or owner has not approved Smokeless for reads
+     *  - No sleep data within the lookback window
+     */
+    fun getWakeTimeMs(nowMs: Long = System.currentTimeMillis()): Long? {
+        if (!isAvailable) return null
+        val lookbackMs = java.util.concurrent.TimeUnit.HOURS.toMillis(24)
+        val startMs = nowMs - lookbackMs
+        val uri = BASE_URI.buildUpon()
+            .appendPath("readings")
+            .appendPath(METRIC_SLEEP_DURATION)
+            .appendQueryParameter("start", startMs.toString())
+            .appendQueryParameter("end", nowMs.toString())
+            .build()
+        return try {
+            context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                val tsCol = cursor.getColumnIndex("timestamp")
+                if (tsCol < 0) return@use null
+                var latest: Long? = null
+                while (cursor.moveToNext()) {
+                    val ts = cursor.getLong(tsCol)
+                    if (ts in startMs..nowMs && (latest == null || ts > latest)) {
+                        latest = ts
+                    }
+                }
+                latest
+            }
+        } catch (e: SecurityException) {
+            Log.d(TAG, "Bios read denied for sleep_duration: ${e.message}")
+            null
+        } catch (e: Exception) {
+            Log.d(TAG, "Bios read failed for sleep_duration: ${e.message}")
+            null
+        }
+    }
+
     fun pushSmokingEvent(timestamp: Long, substance: Substance) =
         push(useMetricFor(substance), timestamp)
 
@@ -174,6 +222,7 @@ class BiosClient(private val context: Context) {
         const val METRIC_TOBACCO_CRAVING = "tobacco_craving"
         const val METRIC_CANNABIS_USE = "cannabis_use"
         const val METRIC_CANNABIS_CRAVING = "cannabis_craving"
+        const val METRIC_SLEEP_DURATION = "sleep_duration"
 
         private val BASE_URI: Uri = Uri.parse("content://com.bios.app.health")
         private val COMPANION_URI: Uri = BASE_URI.buildUpon().appendPath("companion").build()

--- a/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import com.smokless.smokeless.bios.BiosClient
 import com.smokless.smokeless.data.AppDatabase
 import com.smokless.smokeless.data.repository.SmokingRepository
 import com.smokless.smokeless.data.entity.Substance
@@ -36,6 +37,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
     
     private val repository = SmokingRepository(application)
+    private val biosClient = BiosClient(application)
     private val prefs = application.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
     
     // Current time since last smoke (for hero timer)
@@ -432,7 +434,15 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
         // Pedagogical "today vs before" panel inputs.
         _perSubstancePace.postValue(ScoreCalculator.calculatePerSubstancePace(allSessions))
-        _firstSmokeOfDay.postValue(ScoreCalculator.calculateFirstSmokeOfDay(allSessions))
+        // Anchor the "first smoke of today" filter at Bios's last wake-up if
+        // available, so a post-midnight cigarette (user still up from the
+        // prior evening) is correctly counted as that day's last, not the new
+        // day's first. Falls back to calendar midnight when Bios is absent,
+        // READ_HEALTH is not granted, or no sleep was recorded in the last 24h.
+        val wakeTimeMs = biosClient.getWakeTimeMs()
+        _firstSmokeOfDay.postValue(
+            ScoreCalculator.calculateFirstSmokeOfDay(allSessions, dayStartMs = wakeTimeMs)
+        )
         _substanceLevels.postValue(ScoreCalculator.estimateSubstanceLevels(allSessions))
         _triggerWindows.postValue(ScoreCalculator.calculateTriggerWindows(allSessions))
         val cravings = repository.getAllCravings()

--- a/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
@@ -777,8 +777,8 @@ object ScoreCalculator {
      * well-known reduction lever: each delayed hour is real exposure avoided.
      */
     data class FirstSmokeOfDay(
-        /** Milliseconds since start-of-today for the first smoke; null if none yet today. */
-        val todayFirstMsFromStartOfDay: Long?,
+        /** Clock hour-of-day (0..24, e.g. 8.5 for 08:30) of the first smoke since [dayStartMs]. */
+        val todayFirstClockHour: Double?,
         /** Hour-of-day (0..24) of the typical first smoke over the lookback window; null if too little data. */
         val typicalFirstHour: Double?,
         /** today minus typical, in minutes; positive = later than usual (better). null if either side missing. */
@@ -787,27 +787,44 @@ object ScoreCalculator {
         val daysContributing: Int,
     )
 
+    /**
+     * @param dayStartMs anchor for "today's first smoke" — typically the user's
+     *   wake-up time pulled from Bios via [BiosClient.getWakeTimeMs]. When null,
+     *   falls back to calendar midnight (the prior behaviour). The wake anchor
+     *   matters because a smoke at 00:15 by someone still up from the previous
+     *   evening should count as the prior day's *last*, not the new day's
+     *   first.
+     */
     fun calculateFirstSmokeOfDay(
         allSessions: List<SmokingSession>,
         nowMs: Long = System.currentTimeMillis(),
         lookbackDays: Int = 14,
+        dayStartMs: Long? = null,
     ): FirstSmokeOfDay {
-        val cal = Calendar.getInstance().apply {
+        val midnightCal = Calendar.getInstance().apply {
             timeInMillis = nowMs
             set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
             set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
         }
-        val startOfToday = cal.timeInMillis
+        val midnight = midnightCal.timeInMillis
+        // Wake anchor controls *today's* filter only. Prior-day bucketing stays
+        // on calendar midnight — we don't have historical wake-times, and the
+        // typical-hour estimate is a 14-day average that absorbs occasional
+        // post-midnight noise without trouble.
+        val todayAnchor = dayStartMs ?: midnight
         val day = TimeUnit.DAYS.toMillis(1)
         val firstTodayTs = allSessions
-            .filter { it.timestamp >= startOfToday }
+            .filter { it.timestamp >= todayAnchor && it.timestamp <= nowMs }
             .minOfOrNull { it.timestamp }
-        val todayOffsetMs = firstTodayTs?.let { it - startOfToday }
+        val todayClockHour: Double? = firstTodayTs?.let {
+            val c = Calendar.getInstance().apply { timeInMillis = it }
+            c.get(Calendar.HOUR_OF_DAY) + c.get(Calendar.MINUTE) / 60.0
+        }
 
-        // Bucket prior sessions by day and take the earliest each day.
-        val priorStart = startOfToday - lookbackDays * day
+        // Bucket prior sessions by calendar day and take the earliest each day.
+        val priorStart = midnight - lookbackDays * day
         val priorByDay = allSessions
-            .filter { it.timestamp in priorStart until startOfToday }
+            .filter { it.timestamp in priorStart until midnight }
             .groupBy { (it.timestamp - priorStart) / day }
         val firstHours = priorByDay.values.mapNotNull { dayList ->
             val earliest = dayList.minOfOrNull { it.timestamp } ?: return@mapNotNull null
@@ -816,13 +833,12 @@ object ScoreCalculator {
         }
         val typicalHour = if (firstHours.size >= 3) firstHours.average() else null
 
-        val delta: Long? = if (typicalHour != null && todayOffsetMs != null) {
-            val todayHour = todayOffsetMs.toDouble() / TimeUnit.HOURS.toMillis(1)
-            ((todayHour - typicalHour) * 60.0).toLong()
+        val delta: Long? = if (typicalHour != null && todayClockHour != null) {
+            ((todayClockHour - typicalHour) * 60.0).toLong()
         } else null
 
         return FirstSmokeOfDay(
-            todayFirstMsFromStartOfDay = todayOffsetMs,
+            todayFirstClockHour = todayClockHour,
             typicalFirstHour = typicalHour,
             deltaMinutes = delta,
             daysContributing = firstHours.size,

--- a/app/src/test/java/com/smokless/smokeless/util/ProgressionSignalsTest.kt
+++ b/app/src/test/java/com/smokless/smokeless/util/ProgressionSignalsTest.kt
@@ -58,7 +58,7 @@ class ProgressionSignalsTest {
     @Test
     fun `firstSmokeOfDay returns null fields when no data`() {
         val r = ScoreCalculator.calculateFirstSmokeOfDay(emptyList())
-        assertNull(r.todayFirstMsFromStartOfDay)
+        assertNull(r.todayFirstClockHour)
         assertNull(r.typicalFirstHour)
         assertNull(r.deltaMinutes)
         assertEquals(0, r.daysContributing)
@@ -77,7 +77,8 @@ class ProgressionSignalsTest {
         val r = ScoreCalculator.calculateFirstSmokeOfDay(sessions, now)
         assertNotNull(r.typicalFirstHour)
         assertEquals(8.0, r.typicalFirstHour!!, 0.01)
-        assertNotNull(r.todayFirstMsFromStartOfDay)
+        assertNotNull(r.todayFirstClockHour)
+        assertEquals(9.5, r.todayFirstClockHour!!, 0.01)
         // delta: 9:30 minus 8:00 = +90 min
         assertNotNull(r.deltaMinutes)
         assertEquals(90L, r.deltaMinutes)
@@ -94,6 +95,51 @@ class ProgressionSignalsTest {
         )
         val r = ScoreCalculator.calculateFirstSmokeOfDay(sessions, now)
         assertNull(r.typicalFirstHour)
+    }
+
+    @Test
+    fun `firstSmokeOfDay treats post-midnight smoke as new day's first when no wake anchor`() {
+        // User still up from prior evening, smokes at 00:15. Without a wake
+        // anchor, calendar midnight rolls the day and this counts as today's
+        // first — the exact bug the wake-time path is meant to fix.
+        val now = atHour(today(), 11)
+        val sessions = listOf(
+            SmokingSession(atHour(today(), 0) + 15 * 60 * 1000L), // 00:15
+        )
+        val r = ScoreCalculator.calculateFirstSmokeOfDay(sessions, now)
+        assertNotNull(r.todayFirstClockHour)
+        assertEquals(0.25, r.todayFirstClockHour!!, 0.01)
+    }
+
+    @Test
+    fun `firstSmokeOfDay ignores pre-wake smoke when dayStartMs anchors at wake time`() {
+        // Same 00:15 smoke as above, but the user's actual wake-up was 08:00.
+        // With the wake anchor, the 00:15 smoke is excluded — it belongs to
+        // the prior waking day. No smoke since wake → today's first is null.
+        val now = atHour(today(), 11)
+        val wake = atHour(today(), 8)
+        val sessions = listOf(
+            SmokingSession(atHour(today(), 0) + 15 * 60 * 1000L), // 00:15 pre-wake
+        )
+        val r = ScoreCalculator.calculateFirstSmokeOfDay(
+            sessions, now, dayStartMs = wake
+        )
+        assertNull(r.todayFirstClockHour)
+    }
+
+    @Test
+    fun `firstSmokeOfDay reports post-wake smoke clock hour with wake anchor set`() {
+        val now = atHour(today(), 11)
+        val wake = atHour(today(), 8)
+        val sessions = listOf(
+            SmokingSession(atHour(today(), 0) + 15 * 60 * 1000L), // 00:15 pre-wake, ignored
+            SmokingSession(atHour(today(), 9) + 30 * 60 * 1000L), // 09:30 post-wake
+        )
+        val r = ScoreCalculator.calculateFirstSmokeOfDay(
+            sessions, now, dayStartMs = wake
+        )
+        assertNotNull(r.todayFirstClockHour)
+        assertEquals(9.5, r.todayFirstClockHour!!, 0.01)
     }
 
     // --- estimateSubstanceLevels ---


### PR DESCRIPTION
## Summary
- A 00:15 smoke (user still up from prior evening) was being counted as the **next** day's first smoke, garbling the morning-anchor signal.
- `BiosClient.getWakeTimeMs()` now reads the latest `sleep_duration` row from Bios (its `timestamp` = session end = wake-up time) over the last 24h.
- `calculateFirstSmokeOfDay(..., dayStartMs = wakeTime)` filters today's sessions from wake-time instead of calendar midnight; falls back to midnight when Bios is absent, `READ_HEALTH` is not yet granted, or no recent sleep data exists.
- Reshapes the data class: `todayFirstMsFromStartOfDay` → `todayFirstClockHour` (0..24), so the UI reads clock time directly instead of dividing an offset that no longer maps to midnight.
- Declares `com.bios.app.permission.READ_HEALTH` in the manifest. Runtime prompt UX intentionally left for a follow-up — the feature degrades cleanly to the prior midnight behavior until the user opts in.

## Test plan
- [ ] Unit tests in `ProgressionSignalsTest` cover: no-wake-anchor (old behavior preserved), wake-anchor excludes pre-wake post-midnight smoke, wake-anchor reports post-wake smoke clock hour.
- [ ] Verify on device with Bios installed and approved: first smoke clock time matches the actual cigarette logged after waking.
- [ ] Verify on device without Bios: behavior identical to before this PR (anchors at midnight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)