### PR TITLE
Anchor today's pace at wake-time and headline the delta

### DIFF
--- a/app/src/main/java/com/smokless/smokeless/MainActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/MainActivity.kt
@@ -1176,6 +1176,9 @@ class MainActivity : AppCompatActivity() {
     private fun updateTodayPace(pace: com.smokless.smokeless.util.ScoreCalculator.TodayPace) {
         val typicalRounded = kotlin.math.round(pace.typicalByNow).toInt()
         val unit = copy.unitFor(pace.actualToday.toLong())
+        // Signed delta vs typical-by-now: positive = smoked more than usual
+        // (bad), negative = ahead of usual (good), zero = matching pace.
+        val delta = pace.actualToday - typicalRounded
         val (text, colorRes) = when (pace.state) {
             com.smokless.smokeless.util.ScoreCalculator.PaceState.CALIBRATING ->
                 "Keep logging — your pace verdict shows up after 3 days" to R.color.text_secondary
@@ -1192,6 +1195,28 @@ class MainActivity : AppCompatActivity() {
         }
         binding.textTodayPace.text = text
         binding.textTodayPace.setTextColor(ContextCompat.getColor(this, colorRes))
+
+        // Delta badge headline — hidden while calibrating (no baseline yet)
+        // and during clean-baseline states (the copy already says what's
+        // happening, and a "0" badge would be visually noisy).
+        val showBadge = when (pace.state) {
+            com.smokless.smokeless.util.ScoreCalculator.PaceState.CALIBRATING,
+            com.smokless.smokeless.util.ScoreCalculator.PaceState.CLEAN_TODAY,
+            com.smokless.smokeless.util.ScoreCalculator.PaceState.CLEAN_BREAK -> false
+            else -> true
+        }
+        if (showBadge) {
+            val badge = when {
+                delta > 0 -> "+$delta"
+                delta < 0 -> "$delta" // negative sign already included
+                else -> "±0"
+            }
+            binding.textTodayPaceDelta.text = badge
+            binding.textTodayPaceDelta.setTextColor(ContextCompat.getColor(this, colorRes))
+            binding.textTodayPaceDelta.visibility = android.view.View.VISIBLE
+        } else {
+            binding.textTodayPaceDelta.visibility = android.view.View.GONE
+        }
     }
 
     private fun updateReductionTrend(stats: com.smokless.smokeless.util.ScoreCalculator.ReductionStats) {

--- a/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
@@ -308,7 +308,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 else -> ScoreCalculator.PaceState.BEHIND
             }
             _todayPace.postValue(
-                ScoreCalculator.TodayPace(state, paceActualToday, typicalByNow, paceBaselineDailyAvg)
+                ScoreCalculator.TodayPace(
+                    state, paceActualToday, typicalByNow, paceBaselineDailyAvg, paceStartOfToday
+                )
             )
         }
 
@@ -419,27 +421,27 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         totalExposureMs = allSessions.sumOf { it.substance.exposureMs }
         _bankedSmokeFreeMs.postValue(ScoreCalculator.calculateBankedSmokeFreeMs(allSessions))
 
+        // Anchor "today" at Bios's last wake-up if available, so a post-
+        // midnight cigarette (user still up from the prior evening) is
+        // correctly counted in the previous waking stretch and the day-
+        // fraction scaling reflects awake-time, not clock midnight. Falls
+        // back to calendar midnight when Bios is absent, READ_HEALTH is not
+        // granted, or no sleep was recorded in the last 24h.
+        val wakeTimeMs = biosClient.getWakeTimeMs()
+
         // Snapshot today-pace inputs so the per-second tick can re-evaluate
         // the verdict as the day's expected count grows.
-        val pace = ScoreCalculator.calculateTodayPace(allSessions)
+        val pace = ScoreCalculator.calculateTodayPace(allSessions, dayStartMs = wakeTimeMs)
         _todayPace.postValue(pace)
         paceBaselineDailyAvg = pace.baselineDailyAvg
         paceActualToday = pace.actualToday
         paceHasBaseline = pace.state != ScoreCalculator.PaceState.CALIBRATING
-        val cal = Calendar.getInstance().apply {
-            set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
-            set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
-        }
-        paceStartOfToday = cal.timeInMillis
+        paceStartOfToday = pace.dayStartMs
 
         // Pedagogical "today vs before" panel inputs.
-        _perSubstancePace.postValue(ScoreCalculator.calculatePerSubstancePace(allSessions))
-        // Anchor the "first smoke of today" filter at Bios's last wake-up if
-        // available, so a post-midnight cigarette (user still up from the
-        // prior evening) is correctly counted as that day's last, not the new
-        // day's first. Falls back to calendar midnight when Bios is absent,
-        // READ_HEALTH is not granted, or no sleep was recorded in the last 24h.
-        val wakeTimeMs = biosClient.getWakeTimeMs()
+        _perSubstancePace.postValue(
+            ScoreCalculator.calculatePerSubstancePace(allSessions, dayStartMs = wakeTimeMs)
+        )
         _firstSmokeOfDay.postValue(
             ScoreCalculator.calculateFirstSmokeOfDay(allSessions, dayStartMs = wakeTimeMs)
         )

--- a/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
@@ -569,6 +569,13 @@ object ScoreCalculator {
         val actualToday: Int,
         val typicalByNow: Double,
         val baselineDailyAvg: Double,
+        /**
+         * Effective start-of-today anchor used by this computation — either
+         * the wake-time the caller supplied, or calendar midnight as a
+         * fallback. Exposed so per-second UI ticks can re-evaluate the verdict
+         * against the same anchor without re-querying the DB.
+         */
+        val dayStartMs: Long = 0L,
     )
 
     /**
@@ -577,32 +584,47 @@ object ScoreCalculator {
      * baseline excludes today (so a heavy morning doesn't reset its own bar).
      * Requires at least 3 prior days of tracking — fewer than that and we
      * return CALIBRATING rather than a misleading verdict.
+     *
+     * @param dayStartMs anchor for "today's window" — typically the user's
+     *   wake-up time pulled from Bios via [BiosClient.getWakeTimeMs]. When
+     *   null, falls back to calendar midnight (the prior behaviour). The wake
+     *   anchor matters at the day boundary: a 01:00 cigarette from someone
+     *   still up from the evening before should count in that prior waking
+     *   stretch, and the day-fraction scaling should reflect how long the
+     *   user has actually been awake.
      */
     fun calculateTodayPace(
         allSessions: List<SmokingSession>,
         nowMs: Long = System.currentTimeMillis(),
+        dayStartMs: Long? = null,
     ): TodayPace {
-        if (allSessions.isEmpty()) return TodayPace(PaceState.CALIBRATING, 0, 0.0, 0.0)
-
         val cal = Calendar.getInstance().apply {
             timeInMillis = nowMs
             set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
             set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
         }
-        val startOfToday = cal.timeInMillis
-        val actualToday = allSessions.count { it.timestamp >= startOfToday }
+        val midnight = cal.timeInMillis
+        // Wake anchor controls today's session window and the day-fraction
+        // scaling. Prior-day bucketing stays on calendar midnight — we don't
+        // have historical wake-times, and the 14-day average absorbs any
+        // boundary noise (same rationale as calculateFirstSmokeOfDay).
+        val todayAnchor = dayStartMs ?: midnight
+
+        if (allSessions.isEmpty()) return TodayPace(PaceState.CALIBRATING, 0, 0.0, 0.0, todayAnchor)
+
+        val actualToday = allSessions.count { it.timestamp >= todayAnchor }
 
         val day = TimeUnit.DAYS.toMillis(1)
         val firstSession = allSessions.minOf { it.timestamp }
         val trackedDays = ((nowMs - firstSession) / day).toInt() + 1
         val priorDays = (trackedDays - 1).coerceAtMost(14)
-        if (priorDays < 3) return TodayPace(PaceState.CALIBRATING, actualToday, 0.0, 0.0)
+        if (priorDays < 3) return TodayPace(PaceState.CALIBRATING, actualToday, 0.0, 0.0, todayAnchor)
 
-        val priorStart = startOfToday - priorDays * day
-        val priorCount = allSessions.count { it.timestamp in priorStart until startOfToday }
+        val priorStart = midnight - priorDays * day
+        val priorCount = allSessions.count { it.timestamp in priorStart until midnight }
         val baselineDailyAvg = priorCount.toDouble() / priorDays
 
-        val dayFraction = ((nowMs - startOfToday).toDouble() / day).coerceIn(0.0, 1.0)
+        val dayFraction = ((nowMs - todayAnchor).toDouble() / day).coerceIn(0.0, 1.0)
         val typicalByNow = baselineDailyAvg * dayFraction
 
         val state = when {
@@ -611,7 +633,7 @@ object ScoreCalculator {
             actualToday <= typicalByNow * 1.25 -> PaceState.ON_PACE
             else -> PaceState.BEHIND
         }
-        return TodayPace(state, actualToday, typicalByNow, baselineDailyAvg)
+        return TodayPace(state, actualToday, typicalByNow, baselineDailyAvg, todayAnchor)
     }
 
     data class CravingVictories(
@@ -745,6 +767,7 @@ object ScoreCalculator {
     fun calculatePerSubstancePace(
         allSessions: List<SmokingSession>,
         nowMs: Long = System.currentTimeMillis(),
+        dayStartMs: Long? = null,
     ): List<SubstancePace> {
         if (allSessions.isEmpty()) return emptyList()
         val day = TimeUnit.DAYS.toMillis(1)
@@ -753,21 +776,22 @@ object ScoreCalculator {
             .filter { it.timestamp >= lookbackStart }
             .map { it.substance }
             .toSet()
-        // Include substances seen today even if recent window is sparse.
+        // Include substances seen since the wake anchor (or midnight fallback)
+        // even if the 14-day window is sparse.
         val cal = Calendar.getInstance().apply {
             timeInMillis = nowMs
             set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
             set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
         }
-        val startOfToday = cal.timeInMillis
+        val todayAnchor = dayStartMs ?: cal.timeInMillis
         val todaySubstances = allSessions
-            .filter { it.timestamp >= startOfToday }
+            .filter { it.timestamp >= todayAnchor }
             .map { it.substance }
             .toSet()
         val substances = (recentSubstances + todaySubstances).sortedBy { it.ordinal }
         return substances.map { sub ->
             val subset = allSessions.filter { it.substance == sub }
-            SubstancePace(sub, calculateTodayPace(subset, nowMs))
+            SubstancePace(sub, calculateTodayPace(subset, nowMs, dayStartMs))
         }
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -92,20 +92,48 @@
         android:gravity="center"
         android:paddingHorizontal="20dp">
 
-        <TextView
-            android:id="@+id/textTodayPace"
+        <!-- Today's pace chip: the headline delta badge sits above the
+             contextual copy. Badge = signed count vs. typical-by-now
+             (− = ahead, + = behind, ±0 = on pace). Hidden while
+             calibrating and during clean-baseline states (where the copy
+             below carries the full message). -->
+        <LinearLayout
+            android:id="@+id/containerTodayPace"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center"
             android:paddingHorizontal="16dp"
             android:paddingVertical="10dp"
-            android:background="@drawable/bg_stat_chip"
-            android:text="Keep logging — your pace shows up after 3 days"
-            android:textColor="@color/text_secondary"
-            android:textSize="12sp"
-            android:fontFamily="sans-serif-medium"
-            android:gravity="center"
-            android:contentDescription="Today's pace versus your typical pace"
-            android:accessibilityLiveRegion="polite" />
+            android:background="@drawable/bg_stat_chip">
+
+            <TextView
+                android:id="@+id/textTodayPaceDelta"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text=""
+                android:textColor="@color/text_secondary"
+                android:textSize="28sp"
+                android:fontFamily="sans-serif-black"
+                android:letterSpacing="-0.02"
+                android:includeFontPadding="false"
+                android:visibility="gone"
+                android:contentDescription="Number of cigarettes ahead of or behind your usual pace" />
+
+            <TextView
+                android:id="@+id/textTodayPace"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:text="Keep logging — your pace shows up after 3 days"
+                android:textColor="@color/text_secondary"
+                android:textSize="12sp"
+                android:fontFamily="sans-serif-medium"
+                android:gravity="center"
+                android:contentDescription="Today's pace versus your typical pace"
+                android:accessibilityLiveRegion="polite" />
+
+        </LinearLayout>
 
         <LinearLayout
             android:layout_width="wrap_content"

--- a/app/src/test/java/com/smokless/smokeless/util/ScoreCalculatorTest.kt
+++ b/app/src/test/java/com/smokless/smokeless/util/ScoreCalculatorTest.kt
@@ -169,6 +169,51 @@ class ScoreCalculatorTest {
         assertEquals(0, pace.actualToday)
     }
 
+    @Test
+    fun `calculateTodayPace with wake anchor counts post-midnight smokes into the prior waking stretch`() {
+        // Setup: now is 01:00 today. User woke at 07:00 yesterday and is
+        // still up (18h awake). Without a wake anchor, only the 00:30 smoke
+        // is "today" and the projection (1h of 24h elapsed) is tiny, so a
+        // single event reads BEHIND. With wake anchor, the whole awake
+        // window counts and the verdict reflects reality.
+        val hour = 3_600_000L
+        val day = 24 * hour
+        val midnight = paceNow(hourOfDay = 0)
+        val now = midnight + hour // 01:00 today
+        val wake = midnight - day + 7 * hour // yesterday 07:00 (18h before now)
+
+        // 14 prior days, 10 events each at 06:00 — placed before the 07:00
+        // wake anchor so they're clearly pre-wake "prior days" and don't
+        // bleed into the wake-anchored "today" window. trackedDays resolves
+        // to priorDays=13, so d=14 events fall just outside the window:
+        // d=1..13 = 130 events / 13 days = baseline 10/day.
+        val priors = (1..14).flatMap { d ->
+            List(10) { i ->
+                SmokingSession(midnight - d * day + 6 * hour + i * 60_000L)
+                    .apply { id = (d * 1000 + i).toLong() }
+            }
+        }
+
+        // 7 smokes during yesterday's awake hours + 1 post-midnight smoke.
+        val sinceWake = (0..6).map { i ->
+            SmokingSession(wake + i * 2 * hour + 30 * 60_000L)
+                .apply { id = (90_000 + i).toLong() }
+        } + SmokingSession(now - 30 * 60_000L).apply { id = 99_000L } // 00:30 today
+
+        val withoutAnchor = ScoreCalculator.calculateTodayPace(priors + sinceWake, now)
+        // actualToday = the single 00:30 event. typicalByNow ≈ 10 * (1h/24h) = 0.42.
+        // 1 > 0.42 * 1.25 → BEHIND. Misleading — the user is actually on track.
+        assertEquals(ScoreCalculator.PaceState.BEHIND, withoutAnchor.state)
+        assertEquals(1, withoutAnchor.actualToday)
+
+        val withAnchor = ScoreCalculator.calculateTodayPace(priors + sinceWake, now, dayStartMs = wake)
+        // actualToday = 8 (whole awake window). typicalByNow = 10 * (18h/24h) = 7.5.
+        // 8/7.5 ≈ 1.07, within ±25% → ON_PACE.
+        assertEquals(ScoreCalculator.PaceState.ON_PACE, withAnchor.state)
+        assertEquals(8, withAnchor.actualToday)
+        assertEquals(wake, withAnchor.dayStartMs)
+    }
+
     /** Returns a deterministic "now" at a fixed hour of day, avoiding clock flakiness. */
     private fun paceNow(hourOfDay: Int): Long {
         val cal = java.util.Calendar.getInstance().apply {


### PR DESCRIPTION
calculateTodayPace now accepts the same Bios wake-time anchor that calculateFirstSmokeOfDay already uses, so a 01:00 cigarette from someone still up from the previous evening counts in the prior waking stretch instead of flipping the verdict to BEHIND against a near-zero typical-by-now. Prior-day bucketing stays on calendar midnight (no historical wake-times to use).

The pace chip now leads with a signed delta badge ("+3", "-2", "±0") above the contextual copy, so the headline is glanceable as a number, not just a verbal label. Hidden while calibrating and during clean- baseline states where the copy already carries the message.