### PR TITLE
Dose-weight today's pace verdict and headline delta

### DIFF
--- a/app/src/main/java/com/smokless/smokeless/MainActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/MainActivity.kt
@@ -1020,9 +1020,9 @@ class MainActivity : AppCompatActivity() {
         Substance.CANNABIS -> "🌿 Cannabis"
     }
 
-    private fun substanceUnit(substance: Substance, count: Int): String = when (substance) {
-        Substance.TOBACCO -> if (count == 1) "cig" else "cigs"
-        Substance.CANNABIS -> if (count == 1) "session" else "sessions"
+    private fun substanceUnit(substance: Substance, dose: Double): String = when (substance) {
+        Substance.TOBACCO -> if (dose == 1.0) "cig" else "cigs"
+        Substance.CANNABIS -> if (dose == 1.0) "session" else "sessions"
     }
 
     private fun updatePerSubstancePace(entries: List<ScoreCalculator.SubstancePace>) {
@@ -1047,8 +1047,10 @@ class MainActivity : AppCompatActivity() {
 
             label.text = substanceLabel(entry.substance)
             val actualUnit = substanceUnit(entry.substance, entry.pace.actualToday)
-            val typicalInt = entry.pace.typicalByNow.roundToInt()
-            value.text = "${entry.pace.actualToday} $actualUnit today · usually $typicalInt by now"
+            val doseFormat = DecimalFormat("0.##")
+            val actualStr = doseFormat.format(entry.pace.actualToday)
+            val typicalStr = doseFormat.format(entry.pace.typicalByNow)
+            value.text = "$actualStr $actualUnit today · usually $typicalStr by now"
 
             val (verdictText, colorRes) = when (entry.pace.state) {
                 ScoreCalculator.PaceState.CALIBRATING ->
@@ -1174,24 +1176,29 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun updateTodayPace(pace: com.smokless.smokeless.util.ScoreCalculator.TodayPace) {
-        val typicalRounded = kotlin.math.round(pace.typicalByNow).toInt()
-        val unit = copy.unitFor(pace.actualToday.toLong())
-        // Signed delta vs typical-by-now: positive = smoked more than usual
-        // (bad), negative = ahead of usual (good), zero = matching pace.
-        val delta = pace.actualToday - typicalRounded
+        // Dose-weighted — fractions are normal (a "drag" logs 0.25). The 0.##
+        // formatter drops trailing zeros, so whole-cigarette doses still
+        // render cleanly ("5" rather than "5.00").
+        val doseFormat = DecimalFormat("0.##")
+        val actualStr = doseFormat.format(pace.actualToday)
+        val typicalStr = doseFormat.format(pace.typicalByNow)
+        val unit = copy.unitFor(pace.actualToday)
+        // Signed dose-delta vs typical-by-now: positive = smoked more than
+        // usual (bad), negative = ahead of usual (good), zero = matching pace.
+        val delta = pace.actualToday - pace.typicalByNow
         val (text, colorRes) = when (pace.state) {
             com.smokless.smokeless.util.ScoreCalculator.PaceState.CALIBRATING ->
                 "Keep logging — your pace verdict shows up after 3 days" to R.color.text_secondary
             com.smokless.smokeless.util.ScoreCalculator.PaceState.AHEAD ->
-                "Ahead of pace — ${pace.actualToday} $unit today, usually $typicalRounded by now" to R.color.status_champion
+                "Ahead of pace — $actualStr $unit today, usually $typicalStr by now" to R.color.status_champion
             com.smokless.smokeless.util.ScoreCalculator.PaceState.ON_PACE ->
-                "On pace — ${pace.actualToday} $unit today, usually $typicalRounded by now" to R.color.accent_amber
+                "On pace — $actualStr $unit today, usually $typicalStr by now" to R.color.accent_amber
             com.smokless.smokeless.util.ScoreCalculator.PaceState.BEHIND ->
-                "Behind pace — ${pace.actualToday} $unit today, usually $typicalRounded by now" to R.color.status_reset
+                "Behind pace — $actualStr $unit today, usually $typicalStr by now" to R.color.status_reset
             com.smokless.smokeless.util.ScoreCalculator.PaceState.CLEAN_TODAY ->
                 "Matching your clean baseline — 0 today" to R.color.status_champion
             com.smokless.smokeless.util.ScoreCalculator.PaceState.CLEAN_BREAK ->
-                "${pace.actualToday} $unit today — you've been clean lately, gentle reset" to R.color.accent_amber
+                "$actualStr $unit today — you've been clean lately, gentle reset" to R.color.accent_amber
         }
         binding.textTodayPace.text = text
         binding.textTodayPace.setTextColor(ContextCompat.getColor(this, colorRes))
@@ -1206,10 +1213,13 @@ class MainActivity : AppCompatActivity() {
             else -> true
         }
         if (showBadge) {
+            val absStr = doseFormat.format(kotlin.math.abs(delta))
             val badge = when {
-                delta > 0 -> "+$delta"
-                delta < 0 -> "$delta" // negative sign already included
-                else -> "±0"
+                // Within ¼ cigarette of typical reads as on-pace — avoids
+                // showing "+0.1" jitter when the verdict says ON_PACE.
+                kotlin.math.abs(delta) < 0.25 -> "±0"
+                delta > 0 -> "+$absStr"
+                else -> "−$absStr"
             }
             binding.textTodayPaceDelta.text = badge
             binding.textTodayPaceDelta.setTextColor(ContextCompat.getColor(this, colorRes))

--- a/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
@@ -147,7 +147,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     // Snapshot inputs for the today-pace ticker so updateTimer can re-evaluate
     // the pace verdict as the day progresses, without hitting the DB.
     private var paceBaselineDailyAvg = 0.0
-    private var paceActualToday = 0
+    private var paceActualToday = 0.0
     private var paceStartOfToday = 0L
     private var paceHasBaseline = false
 
@@ -301,7 +301,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             val typicalByNow = paceBaselineDailyAvg * dayFraction
             val state = when {
                 paceBaselineDailyAvg < 0.5 ->
-                    if (paceActualToday == 0) ScoreCalculator.PaceState.CLEAN_TODAY
+                    if (paceActualToday < 0.001) ScoreCalculator.PaceState.CLEAN_TODAY
                     else ScoreCalculator.PaceState.CLEAN_BREAK
                 paceActualToday <= typicalByNow * 0.75 -> ScoreCalculator.PaceState.AHEAD
                 paceActualToday <= typicalByNow * 1.25 -> ScoreCalculator.PaceState.ON_PACE

--- a/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
@@ -566,7 +566,14 @@ object ScoreCalculator {
 
     data class TodayPace(
         val state: PaceState,
-        val actualToday: Int,
+        /**
+         * Today's smoking expressed as dose-weighted "cigarette-equivalents"
+         * — sum of [SmokingSession.quantity] over the window, NOT a raw
+         * event count. A user who replaces three full smokes with three
+         * drags shows 0.75 here, not 3, so the verdict correctly registers
+         * the reduction.
+         */
+        val actualToday: Double,
         val typicalByNow: Double,
         val baselineDailyAvg: Double,
         /**
@@ -584,6 +591,11 @@ object ScoreCalculator {
      * baseline excludes today (so a heavy morning doesn't reset its own bar).
      * Requires at least 3 prior days of tracking — fewer than that and we
      * return CALIBRATING rather than a misleading verdict.
+     *
+     * All comparisons are dose-weighted (sum of [SmokingSession.quantity]),
+     * not event counts. This matches [calculateReductionStats] and the
+     * substance app's reduction thesis: replacing full smokes with drags
+     * counts as progress, and the pace verdict reflects that.
      *
      * @param dayStartMs anchor for "today's window" — typically the user's
      *   wake-up time pulled from Bios via [BiosClient.getWakeTimeMs]. When
@@ -610,9 +622,11 @@ object ScoreCalculator {
         // boundary noise (same rationale as calculateFirstSmokeOfDay).
         val todayAnchor = dayStartMs ?: midnight
 
-        if (allSessions.isEmpty()) return TodayPace(PaceState.CALIBRATING, 0, 0.0, 0.0, todayAnchor)
+        if (allSessions.isEmpty()) return TodayPace(PaceState.CALIBRATING, 0.0, 0.0, 0.0, todayAnchor)
 
-        val actualToday = allSessions.count { it.timestamp >= todayAnchor }
+        val actualToday = allSessions
+            .filter { it.timestamp >= todayAnchor }
+            .sumOf { it.quantity }
 
         val day = TimeUnit.DAYS.toMillis(1)
         val firstSession = allSessions.minOf { it.timestamp }
@@ -621,14 +635,16 @@ object ScoreCalculator {
         if (priorDays < 3) return TodayPace(PaceState.CALIBRATING, actualToday, 0.0, 0.0, todayAnchor)
 
         val priorStart = midnight - priorDays * day
-        val priorCount = allSessions.count { it.timestamp in priorStart until midnight }
-        val baselineDailyAvg = priorCount.toDouble() / priorDays
+        val priorDose = allSessions
+            .filter { it.timestamp in priorStart until midnight }
+            .sumOf { it.quantity }
+        val baselineDailyAvg = priorDose / priorDays
 
         val dayFraction = ((nowMs - todayAnchor).toDouble() / day).coerceIn(0.0, 1.0)
         val typicalByNow = baselineDailyAvg * dayFraction
 
         val state = when {
-            baselineDailyAvg < 0.5 -> if (actualToday == 0) PaceState.CLEAN_TODAY else PaceState.CLEAN_BREAK
+            baselineDailyAvg < 0.5 -> if (actualToday < 0.001) PaceState.CLEAN_TODAY else PaceState.CLEAN_BREAK
             actualToday <= typicalByNow * 0.75 -> PaceState.AHEAD
             actualToday <= typicalByNow * 1.25 -> PaceState.ON_PACE
             else -> PaceState.BEHIND

--- a/app/src/main/java/com/smokless/smokeless/util/SubstanceCopy.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/SubstanceCopy.kt
@@ -24,6 +24,8 @@ data class SubstanceCopy(
 ) {
     fun unitFor(count: Long): String = if (count == 1L) unit else units
     fun unitFor(count: Int): String = unitFor(count.toLong())
+    /** Singular only for exactly 1.0; fractional doses use the plural form. */
+    fun unitFor(count: Double): String = if (count == 1.0) unit else units
 
     companion object {
         val TOBACCO = SubstanceCopy(

--- a/app/src/test/java/com/smokless/smokeless/util/ScoreCalculatorTest.kt
+++ b/app/src/test/java/com/smokless/smokeless/util/ScoreCalculatorTest.kt
@@ -115,7 +115,7 @@ class ScoreCalculatorTest {
         )
         val pace = ScoreCalculator.calculateTodayPace(sessions, now)
         assertEquals(ScoreCalculator.PaceState.CALIBRATING, pace.state)
-        assertEquals(1, pace.actualToday)
+        assertEquals(1.0, pace.actualToday, 1e-9)
     }
 
     @Test
@@ -130,7 +130,7 @@ class ScoreCalculatorTest {
         val today = List(4) { SmokingSession(now - it * 60_000L - 7_200_000).apply { id = (1000 + it).toLong() } }
         val pace = ScoreCalculator.calculateTodayPace(priors + today, now)
         assertEquals(ScoreCalculator.PaceState.AHEAD, pace.state)
-        assertEquals(4, pace.actualToday)
+        assertEquals(4.0, pace.actualToday, 1e-9)
     }
 
     @Test
@@ -156,7 +156,7 @@ class ScoreCalculatorTest {
         val today = listOf(SmokingSession(now - 60_000L).apply { id = 2 })
         val pace = ScoreCalculator.calculateTodayPace(priors + today, now)
         assertEquals(ScoreCalculator.PaceState.CLEAN_BREAK, pace.state)
-        assertEquals(1, pace.actualToday)
+        assertEquals(1.0, pace.actualToday, 1e-9)
     }
 
     @Test
@@ -166,7 +166,7 @@ class ScoreCalculatorTest {
         val priors = listOf(SmokingSession(now - 8 * day).apply { id = 1 })
         val pace = ScoreCalculator.calculateTodayPace(priors, now)
         assertEquals(ScoreCalculator.PaceState.CLEAN_TODAY, pace.state)
-        assertEquals(0, pace.actualToday)
+        assertEquals(0.0, pace.actualToday, 1e-9)
     }
 
     @Test
@@ -201,17 +201,46 @@ class ScoreCalculatorTest {
         } + SmokingSession(now - 30 * 60_000L).apply { id = 99_000L } // 00:30 today
 
         val withoutAnchor = ScoreCalculator.calculateTodayPace(priors + sinceWake, now)
-        // actualToday = the single 00:30 event. typicalByNow ≈ 10 * (1h/24h) = 0.42.
-        // 1 > 0.42 * 1.25 → BEHIND. Misleading — the user is actually on track.
+        // actualToday = the single 00:30 event (dose 1.0). typicalByNow ≈
+        // 10 * (1h/24h) = 0.42. 1 > 0.42 * 1.25 → BEHIND. Misleading — the
+        // user is actually on track.
         assertEquals(ScoreCalculator.PaceState.BEHIND, withoutAnchor.state)
-        assertEquals(1, withoutAnchor.actualToday)
+        assertEquals(1.0, withoutAnchor.actualToday, 1e-9)
 
         val withAnchor = ScoreCalculator.calculateTodayPace(priors + sinceWake, now, dayStartMs = wake)
-        // actualToday = 8 (whole awake window). typicalByNow = 10 * (18h/24h) = 7.5.
-        // 8/7.5 ≈ 1.07, within ±25% → ON_PACE.
+        // actualToday = 8 events × dose 1.0 = 8.0 (whole awake window).
+        // typicalByNow = 10 * (18h/24h) = 7.5. 8/7.5 ≈ 1.07, within ±25% → ON_PACE.
         assertEquals(ScoreCalculator.PaceState.ON_PACE, withAnchor.state)
-        assertEquals(8, withAnchor.actualToday)
+        assertEquals(8.0, withAnchor.actualToday, 1e-9)
         assertEquals(wake, withAnchor.dayStartMs)
+    }
+
+    @Test
+    fun `calculateTodayPace AHEAD when same-count today swaps full smokes for drags`() {
+        // Reduction thesis: replacing 5 full smokes with 5 drags is 75%
+        // reduction in exposure. Event count alone would call this "matching
+        // pace" (5 vs 5); dose-weighting correctly flags it AHEAD.
+        val now = paceNow(hourOfDay = 18) // 18/24 = 0.75 day elapsed
+        val day = 24L * 3_600_000
+
+        // 7 prior days of 10 *full* smokes/day → baseline dose 10/day, so
+        // typical-by-now at 18:00 = 7.5.
+        val priors = (1..7).flatMap { d ->
+            List(10) {
+                SmokingSession(now - d * day - it * 60_000L, quantity = 1.0)
+                    .apply { id = (d * 1000 + it).toLong() }
+            }
+        }
+        // Today: 5 drags (quantity 0.25 each) → dose 1.25, well below the
+        // 0.75 × 7.5 = 5.625 cutoff → AHEAD.
+        val today = List(5) {
+            SmokingSession(now - it * 60_000L - 7_200_000, quantity = 0.25)
+                .apply { id = (90_000 + it).toLong() }
+        }
+
+        val pace = ScoreCalculator.calculateTodayPace(priors + today, now)
+        assertEquals(ScoreCalculator.PaceState.AHEAD, pace.state)
+        assertEquals(1.25, pace.actualToday, 1e-9)
     }
 
     /** Returns a deterministic "now" at a fixed hour of day, avoiding clock flakiness. */


### PR DESCRIPTION
calculateTodayPace now sums SmokingSession.quantity instead of counting events, matching calculateReductionStats and the reduction thesis: a user who replaces five full smokes with five drags shows AHEAD (1.25 dose vs 5 baseline) instead of the misleading ON_PACE the count-based comparison gave. The TodayPace.actualToday field changes from Int to Double; the per-second tick and per-substance row track that.

Pace copy and delta badge render fractional doses via DecimalFormat "0.##" (whole doses still render as "5", not "5.00"). The badge uses a ±¼-cig deadband so float jitter doesn't flicker "+0.1" while the verdict reads ON_PACE.