### PR TITLE
Rhythm-aware projection for today's pace

### DIFF
--- a/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
@@ -150,6 +150,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private var paceActualToday = 0.0
     private var paceStartOfToday = 0L
     private var paceHasBaseline = false
+    // Snapshot of the empirical rhythm CDF so the per-second tick can
+    // re-evaluate typical-by-now without re-walking sessions every tick.
+    // Empty when prior data was too sparse to build a stable estimate —
+    // the tick falls back to linear scaling in that case.
+    private var paceRhythmCdf: List<Double> = emptyList()
 
     // Per-substance last-smoke timestamps snapshotted on refresh. The decay
     // ticker re-evaluates each second from these without touching the DB.
@@ -293,12 +298,19 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
         // Re-evaluate today-pace verdict from the cached baseline. The day's
         // expected count grows with elapsed time, so this can flip
-        // BEHIND → ON_PACE → AHEAD without a DB hit.
+        // BEHIND → ON_PACE → AHEAD without a DB hit. typicalByNow tracks the
+        // rhythm CDF when one was snapshotted (so morning-heavy users see
+        // the bulk of typical-by-now early), else linear day-fraction.
         if (paceHasBaseline && paceStartOfToday > 0L) {
             val nowMs = System.currentTimeMillis()
-            val dayMs = java.util.concurrent.TimeUnit.DAYS.toMillis(1)
-            val dayFraction = ((nowMs - paceStartOfToday).toDouble() / dayMs).coerceIn(0.0, 1.0)
-            val typicalByNow = paceBaselineDailyAvg * dayFraction
+            val hourMs = java.util.concurrent.TimeUnit.HOURS.toMillis(1).toDouble()
+            val elapsedHours = (nowMs - paceStartOfToday).toDouble() / hourMs
+            val effectiveFraction = if (paceRhythmCdf.isNotEmpty()) {
+                ScoreCalculator.applyRhythmCdf(paceRhythmCdf, elapsedHours.coerceAtMost(24.0))
+            } else {
+                (elapsedHours / 24.0).coerceIn(0.0, 1.0)
+            }
+            val typicalByNow = paceBaselineDailyAvg * effectiveFraction
             val state = when {
                 paceBaselineDailyAvg < 0.5 ->
                     if (paceActualToday < 0.001) ScoreCalculator.PaceState.CLEAN_TODAY
@@ -309,7 +321,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             }
             _todayPace.postValue(
                 ScoreCalculator.TodayPace(
-                    state, paceActualToday, typicalByNow, paceBaselineDailyAvg, paceStartOfToday
+                    state, paceActualToday, typicalByNow, paceBaselineDailyAvg,
+                    paceStartOfToday, paceRhythmCdf
                 )
             )
         }
@@ -437,6 +450,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         paceActualToday = pace.actualToday
         paceHasBaseline = pace.state != ScoreCalculator.PaceState.CALIBRATING
         paceStartOfToday = pace.dayStartMs
+        paceRhythmCdf = pace.rhythmCdf
 
         // Pedagogical "today vs before" panel inputs.
         _perSubstancePace.postValue(

--- a/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
@@ -583,7 +583,74 @@ object ScoreCalculator {
          * against the same anchor without re-querying the DB.
          */
         val dayStartMs: Long = 0L,
+        /**
+         * Empirical rhythm CDF: flat list of alternating (offsetHours,
+         * cumulativeFraction) pairs, sorted by offset. Encodes the share of
+         * typical-day dose that the user has consumed by each successive
+         * hour-since-wake in the prior window. Empty when the prior pool was
+         * too sparse and the linear projection was used instead. Per-second
+         * UI ticks pass this back to [applyRhythmCdf] so they don't re-walk
+         * the session list every second.
+         */
+        val rhythmCdf: List<Double> = emptyList(),
     )
+
+    /**
+     * Lookup helper for the rhythm CDF stored in [TodayPace.rhythmCdf]. Walks
+     * the (offset, cumulative-fraction) pairs and returns the cumulative
+     * fraction at the largest offset ≤ [elapsedHours], or 0 if elapsed is
+     * before the first event. An empty CDF means "fall back to linear" — the
+     * caller should use [elapsedHours]/24 instead.
+     */
+    fun applyRhythmCdf(cdf: List<Double>, elapsedHours: Double): Double {
+        if (cdf.isEmpty()) return 0.0
+        var frac = 0.0
+        var i = 0
+        while (i < cdf.size) {
+            if (cdf[i] > elapsedHours) break
+            frac = cdf[i + 1]
+            i += 2
+        }
+        return frac
+    }
+
+    /** Clock hour-of-day in [0, 24), e.g. 8.5 for 08:30 — local timezone. */
+    private fun hourOfDay(timestampMs: Long): Double {
+        val c = Calendar.getInstance().apply { timeInMillis = timestampMs }
+        return c.get(Calendar.HOUR_OF_DAY) + c.get(Calendar.MINUTE) / 60.0
+    }
+
+    /**
+     * Build an empirical rhythm CDF from the prior-window sessions, expressed
+     * as offsets from the caller's wake-hour-of-day. An event at clock hour
+     * `h` becomes offset `(h - wakeHour + 24) mod 24` — so events past wake
+     * are early in the awake stretch and pre-wake events sit at the tail
+     * (interpreted as "still up from the previous awake stretch").
+     *
+     * Returns a flat list of pairs (offset, cumulativeFraction) sorted by
+     * offset. Empty if prior data is too sparse for a stable estimate — the
+     * caller should fall back to a linear projection.
+     */
+    private fun buildRhythmCdf(
+        priorSessions: List<SmokingSession>,
+        wakeAnchorMs: Long,
+    ): List<Double> {
+        if (priorSessions.size < 14) return emptyList()
+        val totalDose = priorSessions.sumOf { it.quantity }
+        if (totalDose <= 0.0) return emptyList()
+        val wakeHour = hourOfDay(wakeAnchorMs)
+        val pairs = priorSessions
+            .map { (hourOfDay(it.timestamp) - wakeHour + 24.0) % 24.0 to it.quantity }
+            .sortedBy { it.first }
+        val out = ArrayList<Double>(pairs.size * 2)
+        var cum = 0.0
+        for ((offset, dose) in pairs) {
+            cum += dose
+            out.add(offset)
+            out.add(cum / totalDose)
+        }
+        return out
+    }
 
     /**
      * Compute today's pace against a rolling 14-day baseline, time-of-day
@@ -635,13 +702,25 @@ object ScoreCalculator {
         if (priorDays < 3) return TodayPace(PaceState.CALIBRATING, actualToday, 0.0, 0.0, todayAnchor)
 
         val priorStart = midnight - priorDays * day
-        val priorDose = allSessions
-            .filter { it.timestamp in priorStart until midnight }
-            .sumOf { it.quantity }
+        val priorSessions = allSessions.filter { it.timestamp in priorStart until midnight }
+        val priorDose = priorSessions.sumOf { it.quantity }
         val baselineDailyAvg = priorDose / priorDays
 
-        val dayFraction = ((nowMs - todayAnchor).toDouble() / day).coerceIn(0.0, 1.0)
-        val typicalByNow = baselineDailyAvg * dayFraction
+        // Rhythm-aware projection: empirical CDF of typical-day dose by
+        // hour-since-wake. Falls back to linear when prior data is sparse
+        // (< 14 events) so a calibrating user keeps the simpler behaviour.
+        // Morning-heavy and evening-heavy smokers see verdicts that respect
+        // their actual pattern, not a uniform-day assumption.
+        val hourMs = TimeUnit.HOURS.toMillis(1).toDouble()
+        val elapsedHours = (nowMs - todayAnchor).toDouble() / hourMs
+        val dayFractionLinear = (elapsedHours / 24.0).coerceIn(0.0, 1.0)
+        val rhythmCdf = buildRhythmCdf(priorSessions, todayAnchor)
+        val effectiveFraction = if (rhythmCdf.isNotEmpty()) {
+            applyRhythmCdf(rhythmCdf, elapsedHours.coerceAtMost(24.0))
+        } else {
+            dayFractionLinear
+        }
+        val typicalByNow = baselineDailyAvg * effectiveFraction
 
         val state = when {
             baselineDailyAvg < 0.5 -> if (actualToday < 0.001) PaceState.CLEAN_TODAY else PaceState.CLEAN_BREAK
@@ -649,7 +728,7 @@ object ScoreCalculator {
             actualToday <= typicalByNow * 1.25 -> PaceState.ON_PACE
             else -> PaceState.BEHIND
         }
-        return TodayPace(state, actualToday, typicalByNow, baselineDailyAvg, todayAnchor)
+        return TodayPace(state, actualToday, typicalByNow, baselineDailyAvg, todayAnchor, rhythmCdf)
     }
 
     data class CravingVictories(

--- a/app/src/test/java/com/smokless/smokeless/util/ScoreCalculatorTest.kt
+++ b/app/src/test/java/com/smokless/smokeless/util/ScoreCalculatorTest.kt
@@ -135,14 +135,24 @@ class ScoreCalculatorTest {
 
     @Test
     fun `calculateTodayPace BEHIND when today smoked above 125 percent of typical-by-now`() {
-        val now = paceNow(hourOfDay = 12) // 12/24 = 0.5
+        // 7 prior days × 10 events evenly spread across 24h → baseline 10
+        // and an approximately linear rhythm CDF. At noon, ~60% of typical
+        // dose has happened → typical-by-now ≈ 6. Today: 8 dose → above the
+        // 125% threshold → BEHIND.
+        val midnight = paceNow(hourOfDay = 0)
+        val now = paceNow(hourOfDay = 12)
         val day = 24L * 3_600_000
-        // 7 prior days, 10/day → baseline 10. At noon typical ≈ 5.
-        // Today: 8 → 8/5 = 1.6, above 125% → BEHIND.
+        val hour = 3_600_000L
         val priors = (1..7).flatMap { d ->
-            List(10) { SmokingSession(now - d * day - it * 60_000L).apply { id = (d * 100 + it).toLong() } }
+            (0..9).map { i ->
+                val hourOffset = i * 2.4 // 0, 2.4, 4.8, ..., 21.6
+                SmokingSession(midnight - d * day + (hourOffset * hour).toLong())
+                    .apply { id = (d * 100 + i).toLong() }
+            }
         }
-        val today = List(8) { SmokingSession(now - it * 60_000L - 3_600_000).apply { id = (2000 + it).toLong() } }
+        val today = List(8) {
+            SmokingSession(now - it * 60_000L - 3_600_000).apply { id = (2000 + it).toLong() }
+        }
         val pace = ScoreCalculator.calculateTodayPace(priors + today, now)
         assertEquals(ScoreCalculator.PaceState.BEHIND, pace.state)
     }
@@ -182,14 +192,16 @@ class ScoreCalculatorTest {
         val now = midnight + hour // 01:00 today
         val wake = midnight - day + 7 * hour // yesterday 07:00 (18h before now)
 
-        // 14 prior days, 10 events each at 06:00 — placed before the 07:00
-        // wake anchor so they're clearly pre-wake "prior days" and don't
-        // bleed into the wake-anchored "today" window. trackedDays resolves
-        // to priorDays=13, so d=14 events fall just outside the window:
-        // d=1..13 = 130 events / 13 days = baseline 10/day.
-        val priors = (1..14).flatMap { d ->
-            List(10) { i ->
-                SmokingSession(midnight - d * day + 6 * hour + i * 60_000L)
+        // Prior days 2..14 with 8 events each at 12:00. d=1 (yesterday) is
+        // intentionally skipped so the wake-anchored "today" window — which
+        // starts at yesterday 07:00 and runs to now — only contains the
+        // sinceWake events, not noon-of-yesterday. d=14 falls just outside
+        // the priorDays=13 cutoff; d=2..13 contributes 12 × 8 = 96 events.
+        // Plus the 7 pre-midnight sinceWake events that the calendar-midnight
+        // prior bucket also picks up → baseline ≈ 7.9/day.
+        val priors = (2..14).flatMap { d ->
+            List(8) { i ->
+                SmokingSession(midnight - d * day + 12 * hour + i * 60_000L)
                     .apply { id = (d * 1000 + i).toLong() }
             }
         }
@@ -201,15 +213,19 @@ class ScoreCalculatorTest {
         } + SmokingSession(now - 30 * 60_000L).apply { id = 99_000L } // 00:30 today
 
         val withoutAnchor = ScoreCalculator.calculateTodayPace(priors + sinceWake, now)
-        // actualToday = the single 00:30 event (dose 1.0). typicalByNow ≈
-        // 10 * (1h/24h) = 0.42. 1 > 0.42 * 1.25 → BEHIND. Misleading — the
-        // user is actually on track.
+        // actualToday = the single 00:30 event (dose 1.0). No prior events
+        // ever land in the 00:00–01:00 hour-of-day bucket, so the rhythm
+        // CDF at elapsed=1h is 0 → typicalByNow = 0 → any smoke flags as
+        // BEHIND. Misleading: the user is actually on track for an 18h
+        // awake stretch.
         assertEquals(ScoreCalculator.PaceState.BEHIND, withoutAnchor.state)
         assertEquals(1.0, withoutAnchor.actualToday, 1e-9)
 
         val withAnchor = ScoreCalculator.calculateTodayPace(priors + sinceWake, now, dayStartMs = wake)
-        // actualToday = 8 events × dose 1.0 = 8.0 (whole awake window).
-        // typicalByNow = 10 * (18h/24h) = 7.5. 8/7.5 ≈ 1.07, within ±25% → ON_PACE.
+        // actualToday = 8 events × dose 1.0 = 8.0 (whole awake window). The
+        // rhythm CDF saturates to 1.0 by elapsed=18h (no events sit past
+        // offset 18 in this dataset), so typicalByNow ≈ baseline ≈ 7.9.
+        // 8 vs 7.9 → within ±25% → ON_PACE.
         assertEquals(ScoreCalculator.PaceState.ON_PACE, withAnchor.state)
         assertEquals(8.0, withAnchor.actualToday, 1e-9)
         assertEquals(wake, withAnchor.dayStartMs)
@@ -241,6 +257,39 @@ class ScoreCalculatorTest {
         val pace = ScoreCalculator.calculateTodayPace(priors + today, now)
         assertEquals(ScoreCalculator.PaceState.AHEAD, pace.state)
         assertEquals(1.25, pace.actualToday, 1e-9)
+    }
+
+    @Test
+    fun `calculateTodayPace AHEAD by 11am for a morning-heavy smoker who only did half their typical morning`() {
+        // Morning-heavy pattern: 10 smokes/day all between 06:00 and 10:30.
+        // Linear projection would say typical-by-11am = 10 * 11/24 ≈ 4.6 →
+        // 5 smokes today reads as ON_PACE. Rhythm-aware sees that ~all
+        // smoking normally finishes by 10:30 → typical-by-11am ≈ 10 →
+        // 5 today reads as AHEAD, which is the honest verdict.
+        val midnight = paceNow(hourOfDay = 0)
+        val now = paceNow(hourOfDay = 11)
+        val day = 24L * 3_600_000
+        val hour = 3_600_000L
+
+        // 14 days × 10 events at 06:00, 06:30, ..., 10:30.
+        val morningHalfHours = (0..9).map { 6.0 + it * 0.5 } // 6.0..10.5
+        val priors = (1..14).flatMap { d ->
+            morningHalfHours.mapIndexed { i, h ->
+                SmokingSession(midnight - d * day + (h * hour).toLong())
+                    .apply { id = (d * 100 + i).toLong() }
+            }
+        }
+        // Today: 5 morning smokes at 06:00, 06:30, 07:00, 07:30, 08:00.
+        val today = (0..4).map { i ->
+            SmokingSession(midnight + ((6.0 + i * 0.5) * hour).toLong())
+                .apply { id = (90_000 + i).toLong() }
+        }
+
+        val pace = ScoreCalculator.calculateTodayPace(priors + today, now)
+        assertEquals(ScoreCalculator.PaceState.AHEAD, pace.state)
+        assertEquals(5.0, pace.actualToday, 1e-9)
+        // Rhythm CDF should have been built (≥ 14 prior events).
+        assertTrue(pace.rhythmCdf.isNotEmpty())
     }
 
     /** Returns a deterministic "now" at a fixed hour of day, avoiding clock flakiness. */


### PR DESCRIPTION
## Summary
- `calculateTodayPace` now projects typical-by-now through an empirical CDF of prior-day dose by hour-since-wake, instead of a linear `baseline × elapsed/24h`. A morning-heavy smoker at 11am with half their usual morning dose now correctly reads AHEAD; under linear they'd read ON_PACE (or BEHIND earlier in the morning).
- The CDF travels on `TodayPace.rhythmCdf` so the per-second tick in `MainViewModel` can re-evaluate the verdict via the new public `ScoreCalculator.applyRhythmCdf` helper without re-walking the session list.
- Falls back to linear projection when prior data has < 14 events (calibrating users keep the simpler behavior).

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests com.smokless.smokeless.util.ScoreCalculatorTest` — 21 tests pass
- [x] Updated AHEAD/BEHIND tests to use uniformly-spread priors (old synthetic data clustered at one clock-hour was degenerate under any CDF)
- [x] Updated wake-anchor test to place priors at 12:00 on days 2..14 so they don't bleed into the wake-anchored "today" window
- [x] New test asserts the morning-heavy verdict flip from ON_PACE → AHEAD
- [x] `./gradlew assembleDebug` clean
- [x] Installed + launched on Pixel 9a; pace chip rendered without regressions on a quick visual check

## Notes
Cut from `master`, which does **not** yet include the half-cig deadband from #pace-low-baseline-deadband. If both land, the state-determination block needs a 3-line conflict resolution.