### PR TITLE
Add half-cig deadband floor to low-baseline pace thresholds

### DIFF
--- a/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
@@ -311,13 +311,18 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 (elapsedHours / 24.0).coerceIn(0.0, 1.0)
             }
             val typicalByNow = paceBaselineDailyAvg * effectiveFraction
+            // Threshold logic mirrors ScoreCalculator.calculateTodayPace —
+            // ±25% of typical with an absolute floor of ½ cig-equiv, so
+            // late-stage reduction users don't see whiplash from a single
+            // extra drag. Keep in sync if the calculator changes.
+            val band = max(typicalByNow * 0.25, 0.5)
             val state = when {
                 paceBaselineDailyAvg < 0.5 ->
                     if (paceActualToday < 0.001) ScoreCalculator.PaceState.CLEAN_TODAY
                     else ScoreCalculator.PaceState.CLEAN_BREAK
-                paceActualToday <= typicalByNow * 0.75 -> ScoreCalculator.PaceState.AHEAD
-                paceActualToday <= typicalByNow * 1.25 -> ScoreCalculator.PaceState.ON_PACE
-                else -> ScoreCalculator.PaceState.BEHIND
+                paceActualToday <= typicalByNow - band -> ScoreCalculator.PaceState.AHEAD
+                paceActualToday > typicalByNow + band -> ScoreCalculator.PaceState.BEHIND
+                else -> ScoreCalculator.PaceState.ON_PACE
             }
             _todayPace.postValue(
                 ScoreCalculator.TodayPace(

--- a/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
@@ -722,11 +722,18 @@ object ScoreCalculator {
         }
         val typicalByNow = baselineDailyAvg * effectiveFraction
 
+        // Threshold band around typical-by-now: ±25% of typical, with an
+        // absolute floor of ½ a cigarette-equivalent. The floor matters for
+        // late-stage reduction users (baseline 2–3/day) where a strict ±25%
+        // band is narrower than a single dose, so one extra drag would
+        // otherwise flip the verdict to BEHIND. At higher baselines the
+        // percentage dominates and behavior is unchanged.
+        val band = max(typicalByNow * 0.25, 0.5)
         val state = when {
             baselineDailyAvg < 0.5 -> if (actualToday < 0.001) PaceState.CLEAN_TODAY else PaceState.CLEAN_BREAK
-            actualToday <= typicalByNow * 0.75 -> PaceState.AHEAD
-            actualToday <= typicalByNow * 1.25 -> PaceState.ON_PACE
-            else -> PaceState.BEHIND
+            actualToday <= typicalByNow - band -> PaceState.AHEAD
+            actualToday > typicalByNow + band -> PaceState.BEHIND
+            else -> PaceState.ON_PACE
         }
         return TodayPace(state, actualToday, typicalByNow, baselineDailyAvg, todayAnchor, rhythmCdf)
     }

--- a/app/src/test/java/com/smokless/smokeless/util/ScoreCalculatorTest.kt
+++ b/app/src/test/java/com/smokless/smokeless/util/ScoreCalculatorTest.kt
@@ -232,6 +232,37 @@ class ScoreCalculatorTest {
     }
 
     @Test
+    fun `calculateTodayPace stays ON_PACE at low baselines instead of flipping to BEHIND for one extra dose`() {
+        // Light user: baseline 3 cig/day, spread across morning/midday/evening
+        // so the rhythm CDF at hour 08 lands at ~1/3 → typical-by-now ≈ 1.0.
+        // Under a strict ±25% band, 1.5 today would be BEHIND (1.5 > 1.25).
+        // With the 0.5-dose floor it stays ON_PACE so one unusually intense
+        // morning drag doesn't read as falling off the wagon.
+        val midnight = paceNow(hourOfDay = 0)
+        val now = paceNow(hourOfDay = 8)
+        val day = 24L * 3_600_000
+        val hour = 3_600_000L
+
+        // 5 prior days × 3 events at 04:00, 12:00, 20:00 → 15 events spread
+        // evenly across the day so the CDF approximates linear.
+        val priors = (1..5).flatMap { d ->
+            listOf(4, 12, 20).map { h ->
+                SmokingSession(midnight - d * day + h * hour)
+                    .apply { id = (d * 100 + h).toLong() }
+            }
+        }
+        // Today: 1 full + 1 half = 1.5 dose.
+        val today = listOf(
+            SmokingSession(now - 30 * 60_000L, quantity = 1.0).apply { id = 9001 },
+            SmokingSession(now - 10 * 60_000L, quantity = 0.5).apply { id = 9002 },
+        )
+
+        val pace = ScoreCalculator.calculateTodayPace(priors + today, now)
+        assertEquals(ScoreCalculator.PaceState.ON_PACE, pace.state)
+        assertEquals(1.5, pace.actualToday, 1e-9)
+    }
+
+    @Test
     fun `calculateTodayPace AHEAD when same-count today swaps full smokes for drags`() {
         // Reduction thesis: replacing 5 full smokes with 5 drags is 75%
         // reduction in exposure. Event count alone would call this "matching


### PR DESCRIPTION
## Summary
- Pace state thresholds now use `max(typical × 0.25, 0.5)` as the band around typical-by-now, so a single extra drag at low baselines (2-3 cig/day) stays ON_PACE instead of flipping to BEHIND. High baselines unchanged — the 25% term dominates.
- Per-second tick in MainViewModel mirrors the new logic.

## Test plan
- [x] New unit test: light user (baseline 3/day) at 08:00 with 1.5 dose stays ON_PACE under the deadband, would have read BEHIND under strict ±25%
- [x] All existing `ScoreCalculatorTest` cases pass (22 total)
- [x] `./gradlew assembleDebug` clean
- [x] Rebased onto master post-rhythm-aware (#39) merge; resolved the per-second-tick conflict by composing both improvements (rhythm CDF + deadband)