### PR TITLE
Shrink recovery hero: drop the lifetime banked timer

### DIFF
--- a/app/src/main/java/com/smokless/smokeless/MainActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/MainActivity.kt
@@ -510,15 +510,6 @@ class MainActivity : AppCompatActivity() {
         substance: com.smokless.smokeless.data.entity.Substance,
         quantity: Double = 1.0,
     ) {
-        binding.sectionRecoveryHero.textBankedTimer.animate()
-            .scaleX(0.92f).scaleY(0.92f).alpha(0.6f)
-            .setDuration(150)
-            .withEndAction {
-                binding.sectionRecoveryHero.textBankedTimer.animate()
-                    .scaleX(1f).scaleY(1f).alpha(1f)
-                    .setDuration(200).start()
-            }.start()
-
         viewModel.recordSmokeWithId(exposureOffsetMs, substance, quantity) { sessionId ->
             updateWidgets()
             val bankedMs = viewModel.bankedSmokeFreeMs.value ?: 0L
@@ -673,15 +664,14 @@ class MainActivity : AppCompatActivity() {
     private var primarySubstance: Substance = Substance.DEFAULT
 
     /**
-     * Banked time grows monotonically, but the body's recovery milestones
-     * (heart rate, CO, circulation, etc.) reset after each cigarette — that's
-     * biology, not a UX choice. So the milestone list is driven by the current
-     * clean streak (time since last smoke). Banked stays as the lifetime
-     * "never erased" metric in the timer text above.
+     * Body's recovery milestones (heart rate, CO, circulation, etc.) reset
+     * after each cigarette — that's biology, not a UX choice. So the
+     * milestone list is driven by the current clean streak (time since last
+     * smoke). Lifetime banked time is no longer surfaced here; the
+     * post-log snackbar reframes a slip with banked time when it's
+     * actually motivating.
      */
-    private fun updateRecoveryHero(bankedMs: Long, timeSinceLastSmokeMs: Long) {
-        binding.sectionRecoveryHero.textBankedTimer.text = TimeFormatter.formatShort(bankedMs)
-
+    private fun updateRecoveryHero(timeSinceLastSmokeMs: Long) {
         val cleanHours = timeSinceLastSmokeMs / 3_600_000L
         val substance = primarySubstance
         val milestones = HealthBenefits.getMilestones(cleanHours, substance)
@@ -742,22 +732,18 @@ class MainActivity : AppCompatActivity() {
             // Substance change re-anchors the milestone list. Force a refresh
             // even when the achieved-count number is unchanged.
             lastAchievedCount = -1
-            val banked = viewModel.bankedSmokeFreeMs.value ?: 0L
-            val score = viewModel.currentScore.value ?: 0L
-            updateRecoveryHero(banked, score)
+            updateRecoveryHero(viewModel.currentScore.value ?: 0L)
         }
 
         viewModel.currentScore.observe(this) { score ->
             updatePausedBadge(score)
-            // Milestones reflect the current clean streak, so they update each
-            // tick. Banked timer is refreshed from its own LiveData below.
-            val banked = viewModel.bankedSmokeFreeMs.value ?: 0L
-            updateRecoveryHero(banked, score)
+            // Milestones reflect the current clean streak, so they update each tick.
+            updateRecoveryHero(score)
         }
 
+        // Banked time no longer drives the hero — it surfaces in the records
+        // section and in the post-log snackbar instead.
         viewModel.bankedSmokeFreeMs.observe(this) { ms ->
-            val score = viewModel.currentScore.value ?: 0L
-            updateRecoveryHero(ms, score)
             binding.sectionRecords.textBankedHours.text = TimeFormatter.formatShort(ms)
         }
 
@@ -1311,51 +1297,10 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    /**
-     * Breathing-guided animation on the orb behind the banked timer.
-     * Asymmetric 4s inhale / 6s exhale activates the vagus nerve → parasympathetic
-     * calming. Visual rhythm entrains the user's breath without instruction.
-     */
-    private var breathingAnimator: android.animation.ValueAnimator? = null
-
-    private fun startBreathingAnimation() {
-        if (breathingAnimator != null) return
-        val orb = binding.sectionRecoveryHero.breathingOrb
-        breathingAnimator = android.animation.ValueAnimator.ofFloat(0f, 1f).apply {
-            duration = 10_000L
-            repeatCount = android.animation.ValueAnimator.INFINITE
-            repeatMode = android.animation.ValueAnimator.RESTART
-            interpolator = android.view.animation.LinearInterpolator()
-            addUpdateListener { anim ->
-                val t = anim.animatedValue as Float
-                val breath = if (t < 0.4f) {
-                    val p = t / 0.4f; p * p
-                } else {
-                    val p = (t - 0.4f) / 0.6f; 1f - p * p
-                }
-                orb.scaleX = 0.4f + breath * 0.6f
-                orb.scaleY = 0.4f + breath * 0.6f
-                orb.alpha = breath
-            }
-            start()
-        }
-    }
-
-    private fun stopBreathingAnimation() {
-        breathingAnimator?.cancel()
-        breathingAnimator = null
-        binding.sectionRecoveryHero.breathingOrb.apply {
-            scaleX = 0.4f
-            scaleY = 0.4f
-            alpha = 0f
-        }
-    }
-
     override fun onResume() {
         super.onResume()
         viewModel.refreshData()
         refreshHandler.postDelayed(refreshRunnable, 1000)
-        startBreathingAnimation()
         // Idempotent — schedules only when the alarm hasn't been set yet.
         com.smokless.smokeless.util.TriggerWindowReceiver.schedule(this)
         com.smokless.smokeless.util.WeeklyDigestReceiver.schedule(this)
@@ -1364,7 +1309,6 @@ class MainActivity : AppCompatActivity() {
     override fun onPause() {
         super.onPause()
         refreshHandler.removeCallbacks(refreshRunnable)
-        stopBreathingAnimation()
     }
 
     private fun updateWidgets() {

--- a/app/src/main/res/layout/section_recovery_hero.xml
+++ b/app/src/main/res/layout/section_recovery_hero.xml
@@ -35,74 +35,26 @@
 
     </LinearLayout>
 
-    <!-- Hero card: banked smoke-free time at the center -->
+    <!-- Hero card: recovery milestones. The lifetime banked timer used to
+         sit here behind a breathing orb but the user found it took too much
+         space for too little daily signal — banked time still surfaces in
+         the post-log snackbar where the "still yours" reframe is well-timed. -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:background="@drawable/bg_hero_card"
         android:gravity="center"
-        android:paddingTop="28dp"
-        android:paddingBottom="24dp"
-        android:paddingHorizontal="24dp">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="SMOKE-FREE BANKED"
-            android:textColor="@color/text_tertiary"
-            android:textSize="11sp"
-            android:letterSpacing="0.2"
-            android:fontFamily="sans-serif-medium" />
-
-        <!-- Banked timer with breathing orb behind it -->
-        <FrameLayout
-            android:layout_width="260dp"
-            android:layout_height="220dp"
-            android:layout_marginTop="-12dp"
-            android:layout_marginBottom="-24dp">
-
-            <View
-                android:id="@+id/breathingOrb"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_gravity="center"
-                android:background="@drawable/bg_breathing_orb"
-                android:alpha="0.5" />
-
-            <TextView
-                android:id="@+id/textBankedTimer"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:text="0h"
-                android:textColor="@color/accent_primary"
-                android:textSize="42sp"
-                android:fontFamily="sans-serif-black"
-                android:includeFontPadding="false"
-                android:letterSpacing="-0.02"
-                android:contentDescription="Banked smoke-free time, lifetime additive"
-                android:accessibilityLiveRegion="polite" />
-
-        </FrameLayout>
-
-        <TextView
-            android:id="@+id/textBankedSubtitle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:text="Lifetime cumulative — slips never erase it."
-            android:textColor="@color/text_secondary"
-            android:textSize="12sp"
-            android:gravity="center"
-            android:fontFamily="sans-serif" />
+        android:paddingTop="20dp"
+        android:paddingBottom="20dp"
+        android:paddingHorizontal="20dp">
 
         <!-- Paused-during-exposure badge (visible only while in exposure window) -->
         <TextView
             android:id="@+id/textPausedBadge"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="14dp"
+            android:layout_marginBottom="14dp"
             android:paddingHorizontal="14dp"
             android:paddingVertical="6dp"
             android:background="@drawable/bg_stat_chip"


### PR DESCRIPTION
## Summary
- Removed the 220dp breathing-orb + 42sp banked-time display from the recovery hero card. Lifetime cumulative was static-feeling and ate the screen.
- Milestone progress block (which actually moves with the current clean streak) becomes the focus of the card.
- Banked time still surfaces where it's well-timed:
  - post-log snackbar (\`"X smoke-free banked — still yours"\`)
  - Records section (\`textBankedHours\`)

## Test plan
- [x] \`./gradlew assembleDebug\` clean
- [x] Installed on Pixel 9a; couldn't visually verify (device locked) — please confirm the hero card now leads with the milestone block and the giant orb/timer is gone
- [ ] (Reviewer) eyeball that the snackbar still mentions banked time after logging a smoke

## Notes
\`section_hero.xml\` still references \`breathingOrb\` but that layout has been dead code (not \`<include>\`d anywhere); leaving it alone to keep the diff focused.