### PR TITLE
Raise AHEAD band floor to 1.0 — require a full-dose gap below typical

### DIFF
--- a/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
@@ -257,10 +257,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             // ±25% of typical with an absolute floor of ½ cig-equiv, so
             // late-stage reduction users don't see whiplash from a single
             // extra drag. Keep in sync if the calculator changes.
-            val band = max(typicalByNow * 0.25, 0.5)
+            val band = max(typicalByNow * 0.25, 1.0)
             // Asymmetric verdict — mirrors ScoreCalculator.calculateTodayPace.
             // Any excess above typical-by-now is BEHIND (no tolerance); the
-            // band only widens the AHEAD threshold below.
+            // 1.0-dose floor on the AHEAD side requires a full-dose gap below
+            // typical before claiming "ahead of pace".
             val state = when {
                 paceBaselineDailyAvg < 0.5 ->
                     if (paceActualToday < 0.001) ScoreCalculator.PaceState.CLEAN_TODAY

--- a/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
@@ -648,10 +648,11 @@ object ScoreCalculator {
         // Asymmetric verdict around typical-by-now. The reduction thesis is
         // "smoke strictly less than your typical day", so any excess above
         // typical-by-now means the projected end-of-day total exceeds the
-        // baseline — that's BEHIND, no tolerance. The ±25% / 0.5-dose band
-        // only applies on the AHEAD side, where it sets the threshold for
-        // "meaningfully below typical" vs. "barely below typical".
-        val band = max(typicalByNow * 0.25, 0.5)
+        // baseline — that's BEHIND, no tolerance. The 25% / 1.0-dose band
+        // only applies on the AHEAD side: claiming "ahead of pace" needs a
+        // gap of at least one full dose below typical, otherwise 0 today
+        // vs. 0.93 typical-by-now would read AHEAD when it's really ON_PACE.
+        val band = max(typicalByNow * 0.25, 1.0)
         val state = when {
             baselineDailyAvg < 0.5 -> if (actualToday < 0.001) PaceState.CLEAN_TODAY else PaceState.CLEAN_BREAK
             actualToday <= typicalByNow - band -> PaceState.AHEAD

--- a/app/src/test/java/com/smokless/smokeless/util/ScoreCalculatorTest.kt
+++ b/app/src/test/java/com/smokless/smokeless/util/ScoreCalculatorTest.kt
@@ -202,6 +202,34 @@ class ScoreCalculatorTest {
     }
 
     @Test
+    fun `calculateTodayPace ON_PACE not AHEAD when zero today but typicalByNow under one full dose`() {
+        // Reported bug: 0 today vs typicalByNow 0.93 was reading AHEAD
+        // because the band floored at 0.5 → AHEAD threshold = 0.43 → 0 ≤ 0.43.
+        // Floor is now 1.0, so AHEAD requires a full-dose gap below typical.
+        // With typicalByNow < 1, AHEAD threshold falls below zero, so even a
+        // clean day reads ON_PACE rather than over-claiming.
+        val now = paceNow(hourOfDay = 14)
+        val day = 24L * 3_600_000
+        val hour = 3_600_000L
+        val midnight = paceNow(hourOfDay = 0)
+
+        // 7 prior days × 1 session/day at 12:00 → baseline 1.0. Rhythm CDF
+        // at hour 14 saturates to ~1.0 (events all by noon), so
+        // typicalByNow ≈ 0.93 once smoothing is applied. Today: 0 sessions.
+        val priors = (1..7).flatMap { d ->
+            listOf(12.0).map { h ->
+                SmokingSession(midnight - d * day + (h * hour).toLong(), quantity = 1.0)
+                    .apply { id = (d * 100).toLong() }
+            }
+        }
+
+        val pace = ScoreCalculator.calculateTodayPace(priors, now)
+        assertEquals(ScoreCalculator.PaceState.ON_PACE, pace.state)
+        assertEquals(0.0, pace.actualToday, 1e-9)
+        assertTrue("typicalByNow should be < 1", pace.typicalByNow < 1.0)
+    }
+
+    @Test
     fun `calculateTodayPace BEHIND when actualToday exceeds typicalByNow even by less than the band`() {
         // Reported bug: cannabis user at 1 session vs typical-by-now 0.62
         // (delta +0.38) was reading ON_PACE because the ±0.5 band floor


### PR DESCRIPTION
## Summary
- Floor of 0.5 made "0 today vs 0.93 typical-by-now" read AHEAD when it's really just ON_PACE — claiming "ahead of pace" when the gap is under a single dose overstates progress.
- Bumped to 1.0 so AHEAD honestly means "at least one full dose below typical".
- Follow-up to #44 (which fixed the BEHIND side — any excess over typical is BEHIND with no tolerance).

## Test plan
- [x] New unit test: 0 today + typicalByNow ≈ 0.93 → ON_PACE (was AHEAD)
- [x] Existing AHEAD tests (10/day baseline) still pass — 25% band dominates over 1.0 floor at higher baselines
- [ ] Verify on device: clean day with low typical-by-now reads "On pace" not "Ahead of pace"

🤖 Generated with [Claude Code](https://claude.com/claude-code)