### PR TITLE
Weekly cessation self-eval prompt sheet (closes #46)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,6 +55,11 @@
             android:name=".OnboardingActivity"
             android:theme="@style/Base.Theme.SmokeLess" />
         <activity
+            android:name=".WeeklySelfEvalActivity"
+            android:label="Weekly check-in"
+            android:parentActivityName=".MainActivity"
+            android:exported="false" />
+        <activity
             android:name=".SettingsActivity"
             android:label="Settings"
             android:parentActivityName=".MainActivity"

--- a/app/src/main/java/com/smokless/smokeless/MainActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/MainActivity.kt
@@ -46,6 +46,15 @@ class MainActivity : AppCompatActivity() {
 
     private val refreshHandler = Handler(Looper.getMainLooper())
 
+    private val SELF_EVAL_DIGEST_LABELS: List<Pair<String, String>> = listOf(
+        com.smokless.smokeless.bios.BiosClient.METRIC_SMELL_SELF_RATING to "Smell",
+        com.smokless.smokeless.bios.BiosClient.METRIC_TASTE_SELF_RATING to "Taste",
+        com.smokless.smokeless.bios.BiosClient.METRIC_COUGH_FREQUENCY_SELF_RATING to "Cough",
+        com.smokless.smokeless.bios.BiosClient.METRIC_SPUTUM_SELF_RATING to "Sputum",
+        com.smokless.smokeless.bios.BiosClient.METRIC_BREATH_EASE_SELF_RATING to "Breath",
+        com.smokless.smokeless.bios.BiosClient.METRIC_SMOKER_IDENTITY_SELF_RATING to "Identity",
+    )
+
     private var currentPeriod = "month"
     private var copy: SubstanceCopy = SubstanceCopy.TOBACCO
 
@@ -802,6 +811,43 @@ class MainActivity : AppCompatActivity() {
         } else {
             milestonesText.text = crossed.joinToString(" · ") { "${it.icon} ${it.title}" }
             milestonesGroup.visibility = View.VISIBLE
+        }
+
+        renderSelfEvalTrend(sectionRoot)
+    }
+
+    /**
+     * Prior 4 weekly self-eval ratings per metric — trend only, no judgment.
+     * Renders straight from the local mirror ([WeeklySelfEvalStore]) so the
+     * trend is visible even when Bios isn't installed / approved.
+     */
+    private fun renderSelfEvalTrend(sectionRoot: View) {
+        val rowsGroup = sectionRoot.findViewById<android.widget.LinearLayout>(R.id.groupDigestSelfEvalRows)
+        val empty = sectionRoot.findViewById<android.widget.TextView>(R.id.textDigestSelfEvalEmpty)
+        val openBtn = sectionRoot.findViewById<com.google.android.material.button.MaterialButton>(R.id.btnDigestOpenSelfEval)
+        val store = com.smokless.smokeless.util.WeeklySelfEvalStore(applicationContext)
+
+        rowsGroup.removeAllViews()
+        var anyRendered = false
+        val numFmt = DecimalFormat("0.#")
+        for ((key, label) in SELF_EVAL_DIGEST_LABELS) {
+            val recent = store.recent(key, limit = 4)
+            if (recent.isEmpty()) continue
+            anyRendered = true
+            val row = android.widget.TextView(this).apply {
+                val ordered = recent.reversed() // oldest → newest
+                val nums = ordered.joinToString(" → ") { numFmt.format(it.value) }
+                text = "$label  $nums"
+                setTextColor(ContextCompat.getColor(this@MainActivity, R.color.text_primary))
+                textSize = 13f
+                setPadding(0, (4 * resources.displayMetrics.density).toInt(), 0, 0)
+            }
+            rowsGroup.addView(row)
+        }
+        empty.visibility = if (anyRendered) View.GONE else View.VISIBLE
+
+        openBtn.setOnClickListener {
+            startActivity(Intent(this, WeeklySelfEvalActivity::class.java))
         }
     }
 

--- a/app/src/main/java/com/smokless/smokeless/WeeklySelfEvalActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/WeeklySelfEvalActivity.kt
@@ -1,0 +1,170 @@
+package com.smokless.smokeless
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.slider.Slider
+import com.google.android.material.snackbar.Snackbar
+import com.smokless.smokeless.bios.BiosClient
+import com.smokless.smokeless.data.AppDatabase
+import com.smokless.smokeless.util.WeeklyDigestReceiver
+import com.smokless.smokeless.util.WeeklySelfEvalStore
+import java.text.DecimalFormat
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Sunday-evening self-evaluation prompt sheet — companion-side capture for the
+ * cessation-recovery scales added in Bios #323. Six owner-rated 0–10 sliders
+ * (sensory + respiratory + smoker identity); writes pass through to Bios via
+ * [BiosClient.pushSelfRating] and are mirrored locally so the digest can
+ * render the prior 4-week trend even when Bios isn't installed / approved.
+ *
+ * Skip → no row written. Remind me later → reschedules the digest receiver
+ * 24h forward (and clears the last-fired marker so it can fire that day).
+ */
+class WeeklySelfEvalActivity : AppCompatActivity() {
+
+    private data class Row(
+        val metricKey: String,
+        val title: String,
+        val hint: String,
+        val slider: Slider,
+        val valueView: TextView,
+        val priorView: TextView,
+    )
+
+    private val rows = ArrayList<Row>(6)
+    private lateinit var bios: BiosClient
+    private lateinit var store: WeeklySelfEvalStore
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_weekly_self_eval)
+
+        bios = BiosClient(applicationContext)
+        store = WeeklySelfEvalStore(applicationContext)
+
+        findViewById<MaterialToolbar>(R.id.toolbar).setNavigationOnClickListener { finish() }
+
+        val container = findViewById<LinearLayout>(R.id.groupSelfEvalRows)
+        val inflater = LayoutInflater.from(this)
+        SCALES.forEach { scale ->
+            val view = inflater.inflate(R.layout.item_self_eval_row, container, false)
+            val title = view.findViewById<TextView>(R.id.textSelfEvalRowTitle)
+            val hint = view.findViewById<TextView>(R.id.textSelfEvalRowHint)
+            val valueView = view.findViewById<TextView>(R.id.textSelfEvalRowValue)
+            val priorView = view.findViewById<TextView>(R.id.textSelfEvalRowPrior)
+            val slider = view.findViewById<Slider>(R.id.sliderSelfEvalRow)
+
+            title.text = scale.title
+            hint.text = scale.hint
+            valueView.text = INT_FORMAT.format(slider.value)
+            slider.addOnChangeListener { _, v, _ ->
+                valueView.text = INT_FORMAT.format(v)
+            }
+            renderPrior(scale.metricKey, priorView)
+
+            rows += Row(scale.metricKey, scale.title, scale.hint, slider, valueView, priorView)
+            container.addView(view)
+        }
+
+        findViewById<MaterialButton>(R.id.btnSelfEvalSkip).setOnClickListener {
+            // Skip leaves no row written — neither locally nor in Bios.
+            finish()
+        }
+        findViewById<MaterialButton>(R.id.btnSelfEvalRemindLater).setOnClickListener {
+            WeeklyDigestReceiver.snooze(this, SNOOZE_MS)
+            Snackbar.make(it, "We'll nudge you again tomorrow.", Snackbar.LENGTH_SHORT).show()
+            it.postDelayed({ finish() }, 600L)
+        }
+        findViewById<MaterialButton>(R.id.btnSelfEvalSave).setOnClickListener { saveBtn ->
+            saveBtn.isEnabled = false
+            val timestamp = System.currentTimeMillis()
+            val snapshot = rows.map { it.metricKey to it.slider.value.toDouble() }
+            AppDatabase.databaseExecutor.execute {
+                snapshot.forEach { (key, value) ->
+                    store.save(key, value, timestamp)
+                    // pushSelfRating is best-effort; outcomes (incl. PENDING_APPROVAL)
+                    // are persisted on BiosClient and surfaced from Settings.
+                    bios.pushSelfRating(key, value, timestamp)
+                }
+                runOnUiThread {
+                    Snackbar.make(saveBtn, "Saved — see the digest for the trend.", Snackbar.LENGTH_SHORT).show()
+                    saveBtn.postDelayed({ finish() }, 600L)
+                }
+            }
+        }
+    }
+
+    private fun renderPrior(metricKey: String, priorView: TextView) {
+        val recent = store.recent(metricKey, limit = 4)
+        if (recent.isEmpty()) {
+            priorView.visibility = View.GONE
+            return
+        }
+        // Newest first → reverse for left-to-right oldest→newest trend.
+        val ordered = recent.reversed()
+        val numFmt = DecimalFormat("0.#")
+        val parts = ordered.map { entry ->
+            val dateLabel = DATE_FORMAT.format(Date(entry.timestampMs))
+            "$dateLabel: ${numFmt.format(entry.value)}"
+        }
+        priorView.text = "Prior · " + parts.joinToString(" · ")
+        priorView.visibility = View.VISIBLE
+    }
+
+    private data class Scale(
+        val metricKey: String,
+        val title: String,
+        val hint: String,
+    )
+
+    companion object {
+        const val EXTRA_FROM_DIGEST = "fromDigest"
+
+        private const val SNOOZE_MS = 24L * 60L * 60L * 1000L
+
+        private val INT_FORMAT = DecimalFormat("0")
+        private val DATE_FORMAT = SimpleDateFormat("MMM d", Locale.getDefault())
+
+        private val SCALES: List<Scale> = listOf(
+            Scale(
+                metricKey = BiosClient.METRIC_SMELL_SELF_RATING,
+                title = "Smell",
+                hint = "0 = none · 10 = vivid",
+            ),
+            Scale(
+                metricKey = BiosClient.METRIC_TASTE_SELF_RATING,
+                title = "Taste",
+                hint = "0 = flat · 10 = vivid",
+            ),
+            Scale(
+                metricKey = BiosClient.METRIC_COUGH_FREQUENCY_SELF_RATING,
+                title = "Cough frequency",
+                hint = "0 = none · 10 = constant",
+            ),
+            Scale(
+                metricKey = BiosClient.METRIC_SPUTUM_SELF_RATING,
+                title = "Sputum / morning clearing",
+                hint = "0 = none · 10 = heavy",
+            ),
+            Scale(
+                metricKey = BiosClient.METRIC_BREATH_EASE_SELF_RATING,
+                title = "Breath ease at exertion",
+                hint = "0 = struggling · 10 = effortless",
+            ),
+            Scale(
+                metricKey = BiosClient.METRIC_SMOKER_IDENTITY_SELF_RATING,
+                title = "\"I am a smoker\"",
+                hint = "0 = no · 10 = yes (just track, no direction)",
+            ),
+        )
+    }
+}

--- a/app/src/main/java/com/smokless/smokeless/bios/BiosClient.kt
+++ b/app/src/main/java/com/smokless/smokeless/bios/BiosClient.kt
@@ -113,7 +113,18 @@ class BiosClient(private val context: Context) {
     }
 
     fun pushSmokingEvent(timestamp: Long, substance: Substance) =
-        push(useMetricFor(substance), timestamp)
+        push(useMetricFor(substance), value = 1.0, timestamp = timestamp)
+
+    /**
+     * Pushes a 0–10 owner-rated self-evaluation score (cessation recovery
+     * scales — see [SELF_RATING_KEYS]) to Bios. Same fail-mode semantics as
+     * [pushSmokingEvent]: silent on `isAvailable=false` / `isEnabled=false`,
+     * silent on [SecurityException], outcome recorded via [LastPushOutcome].
+     *
+     * Callers must clamp [value] to [0, 10]; this method does not.
+     */
+    fun pushSelfRating(metricKey: String, value: Double, timestamp: Long): Boolean =
+        push(metricKey, value, timestamp)
 
     /**
      * Replays existing history into Bios. Called from the "Sync history" button —
@@ -133,17 +144,17 @@ class BiosClient(private val context: Context) {
         var pushed = 0
         var failed = 0
         for ((ts, substance) in smokingEvents) {
-            if (push(useMetricFor(substance), ts)) pushed++ else failed++
+            if (push(useMetricFor(substance), value = 1.0, timestamp = ts)) pushed++ else failed++
         }
         return BackfillResult(pushed = pushed, failed = failed, total = total)
     }
 
-    private fun push(metricType: String, timestamp: Long): Boolean {
+    private fun push(metricType: String, value: Double, timestamp: Long): Boolean {
         if (!isEnabled) return false
         if (!isAvailable) return false
         val uri = COMPANION_URI.buildUpon().appendPath(metricType).build()
         val values = ContentValues().apply {
-            put("value", 1.0)
+            put("value", value)
             put("timestamp", timestamp)
         }
         return try {
@@ -214,6 +225,26 @@ class BiosClient(private val context: Context) {
         const val METRIC_TOBACCO_USE = "tobacco_use"
         const val METRIC_CANNABIS_USE = "cannabis_use"
         const val METRIC_SLEEP_DURATION = "sleep_duration"
+
+        // Cessation-recovery self-rating keys — owner-rated 0–10 scales added in
+        // Bios #323. Smokeless captures the cessation-specialty subset (sensory
+        // / respiratory + smoker-identity); mood/energy/focus stay with W2F.
+        const val METRIC_SMELL_SELF_RATING = "smell_self_rating"
+        const val METRIC_TASTE_SELF_RATING = "taste_self_rating"
+        const val METRIC_COUGH_FREQUENCY_SELF_RATING = "cough_frequency_self_rating"
+        const val METRIC_SPUTUM_SELF_RATING = "sputum_self_rating"
+        const val METRIC_BREATH_EASE_SELF_RATING = "breath_ease_self_rating"
+        const val METRIC_SMOKER_IDENTITY_SELF_RATING = "smoker_identity_self_rating"
+
+        /** The 6 keys the weekly self-eval prompt sheet writes to Bios. */
+        val SELF_RATING_KEYS: List<String> = listOf(
+            METRIC_SMELL_SELF_RATING,
+            METRIC_TASTE_SELF_RATING,
+            METRIC_COUGH_FREQUENCY_SELF_RATING,
+            METRIC_SPUTUM_SELF_RATING,
+            METRIC_BREATH_EASE_SELF_RATING,
+            METRIC_SMOKER_IDENTITY_SELF_RATING,
+        )
 
         private val BASE_URI: Uri = Uri.parse("content://com.bios.app.health")
         private val COMPANION_URI: Uri = BASE_URI.buildUpon().appendPath("companion").build()

--- a/app/src/main/java/com/smokless/smokeless/util/NotificationHelper.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/NotificationHelper.kt
@@ -66,8 +66,18 @@ object NotificationHelper {
     ) {
         createTriggerChannel(context)
 
-        val intent = Intent(context, MainActivity::class.java).apply {
+        // Tap → self-eval prompt; the digest recap is one back-press behind.
+        // The self-eval activity short-circuits to no write if the user
+        // hits Skip, matching the "no zero-fill" acceptance criterion.
+        val intent = Intent(
+            context,
+            com.smokless.smokeless.WeeklySelfEvalActivity::class.java,
+        ).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            putExtra(
+                com.smokless.smokeless.WeeklySelfEvalActivity.EXTRA_FROM_DIGEST,
+                true,
+            )
         }
         val pendingIntent = PendingIntent.getActivity(
             context, 0, intent,

--- a/app/src/main/java/com/smokless/smokeless/util/WeeklyDigestReceiver.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/WeeklyDigestReceiver.kt
@@ -65,6 +65,26 @@ class WeeklyDigestReceiver : BroadcastReceiver() {
             alarmManager.cancel(pi)
         }
 
+        /**
+         * Schedule a one-shot follow-up fire of the digest receiver after
+         * [delayMs]. Used by the self-eval "Remind me later" path so the
+         * Sunday-evening nudge re-fires the next day instead of slipping
+         * a full week. Clears [KEY_LAST_FIRED_WEEK] so [evaluate] won't
+         * short-circuit on the same ISO week.
+         */
+        fun snooze(context: Context, delayMs: Long) {
+            if (!isEnabled(context)) return
+            val pi = pendingIntent(context) ?: return
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+                .edit().remove(KEY_LAST_FIRED_WEEK).apply()
+            alarmManager.set(
+                AlarmManager.RTC_WAKEUP,
+                System.currentTimeMillis() + delayMs,
+                pi,
+            )
+        }
+
         private fun nextSundayEvening(now: Long = System.currentTimeMillis()): Long {
             val cal = Calendar.getInstance().apply {
                 timeInMillis = now

--- a/app/src/main/java/com/smokless/smokeless/util/WeeklySelfEvalStore.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/WeeklySelfEvalStore.kt
@@ -1,0 +1,90 @@
+package com.smokless.smokeless.util
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.smokless.smokeless.bios.BiosClient
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Local mirror of the weekly self-evaluation ratings the user submits.
+ *
+ * Bios is the authoritative store, but the digest needs to render the prior
+ * trend even when Bios isn't installed / enabled / approved — and Bios reads
+ * require permission we don't always have. So Smokeless persists its own
+ * rolling history of the values the user submitted from this device.
+ *
+ * Scope: last 12 entries per metric key. The digest renders the most recent
+ * 4; the extra headroom keeps a tiny safety margin and is still trivially
+ * small in SharedPreferences.
+ */
+class WeeklySelfEvalStore(context: Context) {
+
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    data class Entry(val timestampMs: Long, val value: Double)
+
+    /** Append the rating, trim oldest entries past [MAX_PER_KEY]. */
+    fun save(metricKey: String, value: Double, timestampMs: Long) {
+        val arr = readArray(metricKey)
+        arr.put(JSONObject().apply {
+            put(FIELD_TS, timestampMs)
+            put(FIELD_VALUE, value)
+        })
+        val trimmed = trimToMax(arr)
+        prefs.edit().putString(historyKey(metricKey), trimmed.toString()).apply()
+        prefs.edit().putLong(KEY_LAST_SUBMITTED_MS, timestampMs).apply()
+    }
+
+    /** Most recent entries, newest first, up to [limit]. */
+    fun recent(metricKey: String, limit: Int = 4): List<Entry> {
+        val arr = readArray(metricKey)
+        val out = ArrayList<Entry>(arr.length())
+        for (i in 0 until arr.length()) {
+            val obj = arr.optJSONObject(i) ?: continue
+            val ts = obj.optLong(FIELD_TS, 0L)
+            val v = obj.optDouble(FIELD_VALUE, Double.NaN)
+            if (ts > 0 && !v.isNaN()) out += Entry(ts, v)
+        }
+        return out.sortedByDescending { it.timestampMs }.take(limit)
+    }
+
+    /** Most recent submission timestamp across all keys, or null. */
+    fun lastSubmittedMs(): Long? {
+        val v = prefs.getLong(KEY_LAST_SUBMITTED_MS, 0L)
+        return if (v <= 0L) null else v
+    }
+
+    private fun readArray(metricKey: String): JSONArray {
+        val raw = prefs.getString(historyKey(metricKey), null) ?: return JSONArray()
+        return try {
+            JSONArray(raw)
+        } catch (_: Exception) {
+            JSONArray()
+        }
+    }
+
+    private fun trimToMax(arr: JSONArray): JSONArray {
+        if (arr.length() <= MAX_PER_KEY) return arr
+        val sorted = (0 until arr.length()).mapNotNull { arr.optJSONObject(it) }
+            .sortedByDescending { it.optLong(FIELD_TS, 0L) }
+            .take(MAX_PER_KEY)
+        val out = JSONArray()
+        for (obj in sorted) out.put(obj)
+        return out
+    }
+
+    private fun historyKey(metricKey: String): String = "selfEval_${metricKey}_history"
+
+    companion object {
+        private const val PREFS_NAME = "SmokelessPrefs"
+        private const val KEY_LAST_SUBMITTED_MS = "weeklySelfEvalLastSubmittedMs"
+        private const val FIELD_TS = "ts"
+        private const val FIELD_VALUE = "v"
+        private const val MAX_PER_KEY = 12
+
+        /** Convenience exposing the 6 keys the prompt sheet writes. */
+        val KEYS: List<String> = BiosClient.SELF_RATING_KEYS
+    }
+}

--- a/app/src/main/res/drawable/ic_close.xml
+++ b/app/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z" />
+</vector>

--- a/app/src/main/res/layout/activity_weekly_self_eval.xml
+++ b/app/src/main/res/layout/activity_weekly_self_eval.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/background_dark">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="@color/background_dark"
+        app:title="Weekly check-in"
+        app:titleTextColor="@color/text_primary"
+        app:navigationIcon="@drawable/ic_close"
+        app:navigationIconTint="@color/text_primary" />
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true"
+        android:clipToPadding="false"
+        android:paddingBottom="96dp"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="20dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="A quick read on how this week felt — body and identity."
+                android:textColor="@color/text_secondary"
+                android:textSize="14sp"
+                android:lineSpacingMultiplier="1.35" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="0 = lowest · 10 = highest. No averaging, no scoring — just a marker for future you."
+                android:textColor="@color/text_tertiary"
+                android:textSize="12sp"
+                android:lineSpacingMultiplier="1.35" />
+
+            <LinearLayout
+                android:id="@+id/groupSelfEvalRows"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginTop="20dp" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="28dp"
+                android:baselineAligned="false">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnSelfEvalSkip"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="Skip" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnSelfEvalRemindLater"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="8dp"
+                    android:text="Remind me later" />
+
+            </LinearLayout>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnSelfEvalSave"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="Save"
+                app:backgroundTint="@color/accent_primary"
+                android:textColor="@color/background_dark" />
+
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/item_self_eval_row.xml
+++ b/app/src/main/res/layout/item_self_eval_row.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:layout_marginTop="14dp"
+    android:padding="16dp"
+    android:background="@drawable/bg_stat_chip">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:baselineAligned="false">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/textSelfEvalRowTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text=""
+                android:textColor="@color/text_primary"
+                android:textSize="15sp"
+                android:fontFamily="sans-serif-medium" />
+
+            <TextView
+                android:id="@+id/textSelfEvalRowHint"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:text=""
+                android:textColor="@color/text_tertiary"
+                android:textSize="12sp" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/textSelfEvalRowValue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:text="—"
+            android:textColor="@color/accent_primary"
+            android:textSize="22sp"
+            android:fontFamily="sans-serif-black"
+            android:includeFontPadding="false" />
+
+    </LinearLayout>
+
+    <com.google.android.material.slider.Slider
+        android:id="@+id/sliderSelfEvalRow"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:valueFrom="0"
+        android:valueTo="10"
+        android:value="5"
+        android:stepSize="1"
+        app:thumbColor="@color/accent_primary"
+        app:trackColorActive="@color/accent_primary"
+        app:trackColorInactive="@color/progress_track"
+        app:tickColor="@color/text_tertiary"
+        app:tickVisible="false"
+        app:labelBehavior="gone" />
+
+    <TextView
+        android:id="@+id/textSelfEvalRowPrior"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:text=""
+        android:textColor="@color/text_tertiary"
+        android:textSize="11sp"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/section_weekly_digest.xml
+++ b/app/src/main/res/layout/section_weekly_digest.xml
@@ -193,6 +193,53 @@
 
             </LinearLayout>
 
+            <!-- Self-eval check-in: prior 4 weekly ratings + CTA -->
+            <LinearLayout
+                android:id="@+id/groupDigestSelfEval"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="18dp"
+                android:padding="14dp"
+                android:background="@drawable/bg_stat_chip"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="SELF-EVAL TREND"
+                    android:textColor="@color/accent_primary"
+                    android:textSize="10sp"
+                    android:textAllCaps="true"
+                    android:letterSpacing="0.15"
+                    android:fontFamily="sans-serif-medium" />
+
+                <LinearLayout
+                    android:id="@+id/groupDigestSelfEvalRows"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:orientation="vertical" />
+
+                <TextView
+                    android:id="@+id/textDigestSelfEvalEmpty"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:text="No check-ins yet — your trend appears here once you submit one."
+                    android:textColor="@color/text_secondary"
+                    android:textSize="12sp"
+                    android:visibility="gone" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnDigestOpenSelfEval"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:text="📝 This week's check-in" />
+
+            </LinearLayout>
+
         </LinearLayout>
 
     </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary

- Adds a Sunday-evening self-evaluation prompt sheet that captures the six cessation-specialty 0–10 scales added in Bios #323 — smell, taste, cough frequency, sputum, breath-ease, smoker identity.
- `BiosClient.pushSelfRating(metricKey, value, timestamp)` is the new write entry — same silent-fail / `LastPushOutcome` semantics as `pushSmokingEvent`. Local mirror in `WeeklySelfEvalStore` (SharedPreferences JSON, last 12 entries per key) keeps the digest trend viewable when Bios is not installed / not enabled / `PENDING_APPROVAL`.
- The existing weekly digest notification now opens `WeeklySelfEvalActivity` instead of jumping straight to the recap. The digest card gains a *Self-eval trend* group showing the prior 4 ratings per metric plus an always-available "This week's check-in" button.

### Acceptance trace

- [x] Weekly prompt sheet added to `WeeklyDigestReceiver` flow — notification `PendingIntent` now launches `WeeklySelfEvalActivity`
- [x] 6 ratings captured (5 sensory/respiratory + 1 identity)
- [x] Each rating pushes to Bios via `BiosClient.pushSelfRating` using the new MetricType keys
- [x] Skipping leaves no row written (no zero-fill) — Skip button just `finish()`s
- [x] `BiosClient.isEnabled` checked before each push (delegates to existing `push`)
- [x] Renders prior 4 weekly values back in the digest UI (trend only, no judgment)

### Out of scope (per the issue)

- Per-cig trigger-context sidecar, FTND screen, `pushSmokingEvent` quantity-carry-over fix — all explicitly deferred in #46.
- Mood / energy / focus / craving intensity — those keys live with W2F or Bios direct entry, not Smokeless.

## Test plan

- [ ] `./gradlew testDebugUnitTest` — passes locally
- [ ] On a device with Bios installed + approved: install, wait for the Sunday-evening digest (or trigger it manually), tap the notification, submit a check-in, confirm the values arrive in Bios and reappear in the digest trend row.
- [ ] On a device **without** Bios: same flow — values render in the digest trend even though `pushSelfRating` returns false; `LastPushOutcome` stays `NEVER_TRIED`.
- [ ] Bios installed but **not** approved: submit a check-in, confirm `LastPushOutcome` flips to `PENDING_APPROVAL` and the Settings banner surfaces it.
- [ ] Tap *Skip* — no row appears in the digest trend; no Bios push attempted.
- [ ] Tap *Remind me later* — digest receiver fires again ~24h later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)