### PR TITLE
Keep weekly check-in nudge firing after quitting

### DIFF
--- a/app/src/main/java/com/smokless/smokeless/util/NotificationHelper.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/NotificationHelper.kt
@@ -63,6 +63,7 @@ object NotificationHelper {
         context: Context,
         digest: ScoreCalculator.WeeklyDigest,
         copy: SubstanceCopy,
+        daysSinceLastSmoke: Long = 0L,
     ) {
         createTriggerChannel(context)
 
@@ -84,6 +85,12 @@ object NotificationHelper {
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
 
+        // Past 14 days of zero smoking, the recap "0 cigs · 7/7 clean" repeats
+        // every Sunday and decays into noise — but the cessation-recovery
+        // self-eval (smell / taste / breath) only gets more useful with time.
+        // So switch the notification headline to lead with the check-in.
+        val checkInOnly = daysSinceLastSmoke >= 14
+
         val unit = if (kotlin.math.abs(digest.smokesThisWeek - 1.0) < 0.01)
             copy.unit else copy.units
         val displayCount = formatWeeklyCount(digest.smokesThisWeek)
@@ -96,18 +103,30 @@ object NotificationHelper {
             change <= -5 -> " (↑ ${(-change).toInt()}% vs last week)"
             else -> ""
         }
-        val title = "🌿 Your week in review"
-        val short = "$displayCount $unit · ${digest.cleanDaysThisWeek}/7 clean$changeLine"
+        val title: String
+        val short: String
         val longLines = mutableListOf<String>()
-        longLines += "$displayCount $unit this week$changeLine."
-        if (digest.cleanDaysThisWeek > 0) {
-            longLines += "${digest.cleanDaysThisWeek}/7 clean days."
+        if (checkInOnly) {
+            title = "📝 Weekly check-in"
+            short = "Smell, taste, breath — how's this week?"
+            longLines += "Tap to log this week's self-eval."
+            if (digest.cleanDaysThisWeek == 7) {
+                val weeks = daysSinceLastSmoke / 7
+                if (weeks >= 1) longLines += "${weeks} week${if (weeks == 1L) "" else "s"} smoke-free — recovery's compounding."
+            }
+        } else {
+            title = "🌿 Your week in review"
+            short = "$displayCount $unit · ${digest.cleanDaysThisWeek}/7 clean$changeLine"
+            longLines += "$displayCount $unit this week$changeLine."
+            if (digest.cleanDaysThisWeek > 0) {
+                longLines += "${digest.cleanDaysThisWeek}/7 clean days."
+            }
+            if (digest.milestonesReachedThisWeek.isNotEmpty()) {
+                val list = digest.milestonesReachedThisWeek.joinToString(" · ") { "${it.icon} ${it.title}" }
+                longLines += "Milestones crossed: $list."
+            }
+            longLines += "Tap to see the full recap."
         }
-        if (digest.milestonesReachedThisWeek.isNotEmpty()) {
-            val list = digest.milestonesReachedThisWeek.joinToString(" · ") { "${it.icon} ${it.title}" }
-            longLines += "Milestones crossed: $list."
-        }
-        longLines += "Tap to see the full recap."
 
         val notification = NotificationCompat.Builder(context, TRIGGER_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_check)

--- a/app/src/main/java/com/smokless/smokeless/util/WeeklyDigestReceiver.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/WeeklyDigestReceiver.kt
@@ -139,14 +139,16 @@ class WeeklyDigestReceiver : BroadcastReceiver() {
 
         val db = AppDatabase.getInstance(context)
         val sessions = db.smokingSessionDao().getAllSessions()
+        // Require at least one historical session before ever firing — covers
+        // the "installed once, never logged" edge case. After that the nudge
+        // keeps firing weekly forever (including post-quit), because the
+        // self-eval check-in is most useful when sensory/respiratory recovery
+        // is compounding.
         if (sessions.isEmpty()) return
 
-        // Don't nudge users who haven't logged in a long time — the recap
-        // would mostly be stale zeros, and the unsolicited ping feels worse
-        // than skipping it.
         val mostRecent = sessions.maxOf { it.timestamp }
         val day = TimeUnit.DAYS.toMillis(1)
-        if (now - mostRecent > 14 * day) return
+        val daysSinceLastSmoke = (now - mostRecent) / day
 
         val primary = SubstanceCopy.primarySubstance(sessions)
         val digest = ScoreCalculator.calculateWeeklyDigest(
@@ -157,6 +159,11 @@ class WeeklyDigestReceiver : BroadcastReceiver() {
         val copy = SubstanceCopy.forSubstance(primary)
 
         prefs.edit().putString(KEY_LAST_FIRED_WEEK, weekKey).apply()
-        NotificationHelper.showWeeklyDigestNotification(context, digest, copy)
+        NotificationHelper.showWeeklyDigestNotification(
+            context = context,
+            digest = digest,
+            copy = copy,
+            daysSinceLastSmoke = daysSinceLastSmoke,
+        )
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #47. The Sunday-evening digest receiver previously bailed out at [WeeklyDigestReceiver.kt:149](app/src/main/java/com/smokless/smokeless/util/WeeklyDigestReceiver.kt#L149) if no smoking session had been logged in 14 days — so a user who's quit stops getting the nudge exactly when the cessation-recovery self-eval (smell / taste / breath-ease) becomes most useful.

- Drop the 14-day stale-data guard. Still require at least one historical session before the nudge ever fires (covers the "installed once, never logged" case).
- Past 14 quit days, switch the notification headline from "🌿 Your week in review" (which would otherwise repeat "0 cigs · 7/7 clean" every Sunday and decay into noise) to "📝 Weekly check-in" so the prompt stays meaningful.

## Test plan

- [ ] Existing unit tests pass (`./gradlew testDebugUnitTest`).
- [ ] On a device with smoking history >14 days old: trigger the digest alarm, confirm the notification fires with the "📝 Weekly check-in" headline and tap → self-eval sheet.
- [ ] On a device that's smoked this week: notification still uses the existing "🌿 Your week in review" recap.
- [ ] On a brand-new install with zero sessions: no notification fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)