### PR TITLE
Self-eval: stats card + onboarding baseline

### DIFF
--- a/app/src/main/java/com/smokless/smokeless/MainActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/MainActivity.kt
@@ -1236,6 +1236,71 @@ class MainActivity : AppCompatActivity() {
         // Idempotent — schedules only when the alarm hasn't been set yet.
         com.smokless.smokeless.util.TriggerWindowReceiver.schedule(this)
         com.smokless.smokeless.util.WeeklyDigestReceiver.schedule(this)
+        updateSelfEvalStats()
+    }
+
+    /**
+     * Renders the "Subjective Scales" stats card — latest weekly value per
+     * metric plus the delta against the prior entry. Period-agnostic (the
+     * scales are captured weekly, so the period-chip framing doesn't apply).
+     * Tap the CTA → opens the carousel to update this week's check-in.
+     */
+    private fun updateSelfEvalStats() {
+        val sectionRoot = binding.sectionSelfEvalStats.root
+        val rowsGroup = sectionRoot.findViewById<android.widget.LinearLayout>(R.id.groupSelfEvalStatRows)
+        val empty = sectionRoot.findViewById<android.widget.TextView>(R.id.textSelfEvalStatsEmpty)
+        val openBtn = sectionRoot.findViewById<com.google.android.material.button.MaterialButton>(R.id.btnSelfEvalStatsOpen)
+        val store = com.smokless.smokeless.util.WeeklySelfEvalStore(applicationContext)
+        val inflater = layoutInflater
+        val numFmt = DecimalFormat("0.#")
+
+        rowsGroup.removeAllViews()
+        var anyRendered = false
+        for ((key, label) in SELF_EVAL_DIGEST_LABELS) {
+            val recent = store.recent(key, limit = 4)
+            if (recent.isEmpty()) continue
+            anyRendered = true
+
+            val row = inflater.inflate(R.layout.item_self_eval_stat_row, rowsGroup, false)
+            val labelView = row.findViewById<android.widget.TextView>(R.id.textStatRowLabel)
+            val sparklineView = row.findViewById<android.widget.TextView>(R.id.textStatRowSparkline)
+            val valueView = row.findViewById<android.widget.TextView>(R.id.textStatRowValue)
+            val deltaView = row.findViewById<android.widget.TextView>(R.id.textStatRowDelta)
+
+            labelView.text = label
+            val latest = recent.first()
+            valueView.text = numFmt.format(latest.value)
+
+            if (recent.size >= 2) {
+                val prior = recent[1]
+                val delta = latest.value - prior.value
+                val absStr = numFmt.format(kotlin.math.abs(delta))
+                // Direction-only badge — "no judgment" per the cessation
+                // manifesto. Polarities differ across these scales (↓ cough
+                // is desirable, ↓ smell isn't), so the owner reads the
+                // direction; the app doesn't moralise.
+                val badge = when {
+                    kotlin.math.abs(delta) < 0.5 -> "→ steady"
+                    delta > 0 -> "↑ +$absStr"
+                    else -> "↓ −$absStr"
+                }
+                deltaView.text = badge
+                deltaView.setTextColor(ContextCompat.getColor(this, R.color.text_secondary))
+                deltaView.visibility = View.VISIBLE
+            } else {
+                deltaView.visibility = View.GONE
+            }
+
+            // Oldest → newest sparkline so the trend reads left-to-right.
+            val ordered = recent.reversed()
+            sparklineView.text = ordered.joinToString(" → ") { numFmt.format(it.value) }
+
+            rowsGroup.addView(row)
+        }
+        empty.visibility = if (anyRendered) View.GONE else View.VISIBLE
+        openBtn.setOnClickListener {
+            startActivity(Intent(this, WeeklySelfEvalActivity::class.java))
+        }
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/smokless/smokeless/OnboardingActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/OnboardingActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
 import android.widget.RadioGroup
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
@@ -13,7 +14,10 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.slider.Slider
+import com.smokless.smokeless.bios.BiosClient
+import com.smokless.smokeless.data.AppDatabase
 import com.smokless.smokeless.databinding.ActivityOnboardingBinding
+import com.smokless.smokeless.util.WeeklySelfEvalStore
 
 class OnboardingActivity : AppCompatActivity() {
 
@@ -26,6 +30,9 @@ class OnboardingActivity : AppCompatActivity() {
         private const val KEY_BASELINE_CIGS = "baselineCigs"
         private const val KEY_DIFFICULTY = "difficultyLevel"
 
+        // Welcome → Goal → Baseline cig count → Baseline self-eval → Ready
+        private const val PAGE_COUNT = 5
+
         fun isOnboardingDone(context: Context): Boolean {
             return context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
                 .getBoolean(KEY_ONBOARDING_DONE, false)
@@ -34,6 +41,14 @@ class OnboardingActivity : AppCompatActivity() {
 
     private var selectedGoal = "reduce"
     private var baselineCigs = 10
+
+    /**
+     * Baseline self-eval ratings the user touches during onboarding. Only
+     * touched sliders end up here — matches the "no zero-fill" rule, so
+     * untouched scales stay empty and the user can rate them later from
+     * the weekly carousel.
+     */
+    private val selfEvalBaseline: MutableMap<String, Double> = mutableMapOf()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -56,7 +71,7 @@ class OnboardingActivity : AppCompatActivity() {
     }
 
     private fun setupIndicators() {
-        val count = 4
+        val count = PAGE_COUNT
         for (i in 0 until count) {
             val dot = View(this).apply {
                 layoutParams = ViewGroup.MarginLayoutParams(8.dp, 8.dp).apply {
@@ -84,7 +99,7 @@ class OnboardingActivity : AppCompatActivity() {
     }
 
     private fun updateButton(position: Int) {
-        if (position == 3) {
+        if (position == PAGE_COUNT - 1) {
             binding.btnNext.text = "Get Started"
         } else {
             binding.btnNext.text = "Next"
@@ -94,7 +109,7 @@ class OnboardingActivity : AppCompatActivity() {
     private fun setupButtons() {
         binding.btnNext.setOnClickListener {
             val current = binding.viewPager.currentItem
-            if (current < 3) {
+            if (current < PAGE_COUNT - 1) {
                 binding.viewPager.currentItem = current + 1
             } else {
                 finishOnboarding()
@@ -119,16 +134,38 @@ class OnboardingActivity : AppCompatActivity() {
             })
             .apply()
 
+        persistSelfEvalBaseline()
+
         com.smokless.smokeless.util.ReminderReceiver.schedule(this)
         startActivity(Intent(this, MainActivity::class.java))
         finish()
+    }
+
+    /**
+     * Persist whichever baseline self-eval sliders the user touched. Untouched
+     * scales stay empty — they can be filled in from the weekly check-in
+     * carousel later. Mirrors the live runtime path: local store + Bios push,
+     * silent-fail semantics from BiosClient.
+     */
+    private fun persistSelfEvalBaseline() {
+        if (selfEvalBaseline.isEmpty()) return
+        val snapshot = selfEvalBaseline.toMap()
+        val timestamp = System.currentTimeMillis()
+        val store = WeeklySelfEvalStore(applicationContext)
+        val bios = BiosClient(applicationContext)
+        AppDatabase.databaseExecutor.execute {
+            for ((key, value) in snapshot) {
+                store.save(key, value, timestamp)
+                bios.pushSelfRating(key, value, timestamp)
+            }
+        }
     }
 
     private val Int.dp: Int get() = (this * resources.displayMetrics.density).toInt()
 
     inner class OnboardingAdapter : RecyclerView.Adapter<OnboardingAdapter.PageViewHolder>() {
 
-        override fun getItemCount() = 4
+        override fun getItemCount() = PAGE_COUNT
 
         override fun getItemViewType(position: Int) = position
 
@@ -137,6 +174,7 @@ class OnboardingActivity : AppCompatActivity() {
                 0 -> R.layout.fragment_onboarding_welcome
                 1 -> R.layout.fragment_onboarding_goal
                 2 -> R.layout.fragment_onboarding_baseline
+                3 -> R.layout.fragment_onboarding_self_eval_baseline
                 else -> R.layout.fragment_onboarding_ready
             }
             val view = LayoutInflater.from(parent.context).inflate(layoutId, parent, false)
@@ -147,6 +185,7 @@ class OnboardingActivity : AppCompatActivity() {
             when (position) {
                 1 -> bindGoalPage(holder.itemView)
                 2 -> bindBaselinePage(holder.itemView)
+                3 -> bindSelfEvalBaselinePage(holder.itemView)
             }
         }
 
@@ -171,6 +210,51 @@ class OnboardingActivity : AppCompatActivity() {
             }
         }
 
+        /**
+         * Renders one compact row per cessation-recovery scale. Only sliders
+         * the user actually releases (onStopTrackingTouch) get added to
+         * [selfEvalBaseline] — untouched scales stay out of the map and the
+         * user can rate them later from the weekly carousel.
+         */
+        private fun bindSelfEvalBaselinePage(view: View) {
+            val container = view.findViewById<LinearLayout>(R.id.groupBaselineSelfEvalRows)
+            if (container.childCount > 0) return // already bound
+            val inflater = LayoutInflater.from(view.context)
+            for (scale in BASELINE_SCALES) {
+                val row = inflater.inflate(R.layout.item_onboarding_self_eval_row, container, false)
+                val title = row.findViewById<TextView>(R.id.textOnboardingRowTitle)
+                val hint = row.findViewById<TextView>(R.id.textOnboardingRowHint)
+                val value = row.findViewById<TextView>(R.id.textOnboardingRowValue)
+                val slider = row.findViewById<Slider>(R.id.sliderOnboardingRow)
+                title.text = scale.title
+                hint.text = scale.hint
+                slider.addOnChangeListener { _, v, _ ->
+                    value.text = v.toInt().toString()
+                    value.setTextColor(
+                        ContextCompat.getColor(this@OnboardingActivity, R.color.accent_primary)
+                    )
+                }
+                slider.addOnSliderTouchListener(object : Slider.OnSliderTouchListener {
+                    override fun onStartTrackingTouch(slider: Slider) {}
+                    override fun onStopTrackingTouch(slider: Slider) {
+                        selfEvalBaseline[scale.metricKey] = slider.value.toDouble()
+                    }
+                })
+                container.addView(row)
+            }
+        }
+
         inner class PageViewHolder(view: View) : RecyclerView.ViewHolder(view)
     }
+
+    private data class Scale(val metricKey: String, val title: String, val hint: String)
+
+    private val BASELINE_SCALES: List<Scale> = listOf(
+        Scale(BiosClient.METRIC_SMELL_SELF_RATING, "Smell", "0 = none · 10 = vivid"),
+        Scale(BiosClient.METRIC_TASTE_SELF_RATING, "Taste", "0 = flat · 10 = vivid"),
+        Scale(BiosClient.METRIC_COUGH_FREQUENCY_SELF_RATING, "Cough frequency", "0 = none · 10 = constant"),
+        Scale(BiosClient.METRIC_SPUTUM_SELF_RATING, "Sputum / morning clearing", "0 = none · 10 = heavy"),
+        Scale(BiosClient.METRIC_BREATH_EASE_SELF_RATING, "Breath ease at exertion", "0 = struggling · 10 = effortless"),
+        Scale(BiosClient.METRIC_SMOKER_IDENTITY_SELF_RATING, "\"I am a smoker\"", "0 = doesn't fit · 10 = fits exactly"),
+    )
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -188,6 +188,8 @@
 
                 <include android:id="@+id/sectionStatistics" layout="@layout/section_statistics" />
 
+                <include android:id="@+id/sectionSelfEvalStats" layout="@layout/section_self_eval_stats" />
+
                 <include android:id="@+id/sectionCharts" layout="@layout/section_charts" />
 
                 <include android:id="@+id/sectionRecords" layout="@layout/section_records" />

--- a/app/src/main/res/layout/fragment_onboarding_self_eval_baseline.xml
+++ b/app/src/main/res/layout/fragment_onboarding_self_eval_baseline.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="24dp"
+        android:paddingTop="32dp"
+        android:paddingBottom="32dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="🌱"
+            android:textSize="44sp"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginBottom="16dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Where are you starting?"
+            android:textColor="@color/text_primary"
+            android:textSize="22sp"
+            android:fontFamily="sans-serif-bold"
+            android:gravity="center"
+            android:layout_marginBottom="8dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="A quick snapshot now so future check-ins have a true baseline to compare against. Touch any slider to log it — skip what you'd rather rate later."
+            android:textColor="@color/text_secondary"
+            android:textSize="13sp"
+            android:lineSpacingMultiplier="1.4"
+            android:gravity="center"
+            android:layout_marginBottom="20dp" />
+
+        <LinearLayout
+            android:id="@+id/groupBaselineSelfEvalRows"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+
+    </LinearLayout>
+
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/item_onboarding_self_eval_row.xml
+++ b/app/src/main/res/layout/item_onboarding_self_eval_row.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:layout_marginTop="10dp"
+    android:padding="14dp"
+    android:background="@drawable/bg_stat_chip">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:baselineAligned="false">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/textOnboardingRowTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text=""
+                android:textColor="@color/text_primary"
+                android:textSize="14sp"
+                android:fontFamily="sans-serif-medium" />
+
+            <TextView
+                android:id="@+id/textOnboardingRowHint"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:text=""
+                android:textColor="@color/text_tertiary"
+                android:textSize="11sp" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/textOnboardingRowValue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:text="—"
+            android:textColor="@color/text_tertiary"
+            android:textSize="20sp"
+            android:fontFamily="sans-serif-black"
+            android:includeFontPadding="false" />
+
+    </LinearLayout>
+
+    <com.google.android.material.slider.Slider
+        android:id="@+id/sliderOnboardingRow"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:valueFrom="0"
+        android:valueTo="10"
+        android:value="5"
+        android:stepSize="1"
+        app:thumbColor="@color/accent_primary"
+        app:trackColorActive="@color/accent_primary"
+        app:trackColorInactive="@color/progress_track"
+        app:tickColor="@color/text_tertiary"
+        app:tickVisible="false"
+        app:labelBehavior="gone" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_self_eval_stat_row.xml
+++ b/app/src/main/res/layout/item_self_eval_stat_row.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingVertical="10dp"
+    android:gravity="center_vertical"
+    android:baselineAligned="false">
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/textStatRowLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text=""
+            android:textColor="@color/text_primary"
+            android:textSize="14sp"
+            android:fontFamily="sans-serif-medium" />
+
+        <TextView
+            android:id="@+id/textStatRowSparkline"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="2dp"
+            android:text=""
+            android:textColor="@color/text_tertiary"
+            android:textSize="11sp"
+            android:fontFamily="monospace" />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/textStatRowDelta"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="12dp"
+        android:paddingHorizontal="8dp"
+        android:paddingVertical="4dp"
+        android:background="@drawable/bg_stat_chip"
+        android:text=""
+        android:textColor="@color/text_secondary"
+        android:textSize="11sp"
+        android:fontFamily="sans-serif-medium"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/textStatRowValue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="—"
+        android:textColor="@color/accent_primary"
+        android:textSize="22sp"
+        android:fontFamily="sans-serif-black"
+        android:includeFontPadding="false" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/section_self_eval_stats.xml
+++ b/app/src/main/res/layout/section_self_eval_stats.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:layout_marginBottom="20dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_marginBottom="14dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Subjective Scales"
+            android:textColor="@color/text_primary"
+            android:textSize="19sp"
+            android:fontFamily="sans-serif-bold" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="Owner-rated cessation recovery — captured each Sunday"
+            android:textColor="@color/text_tertiary"
+            android:textSize="12sp"
+            android:fontFamily="sans-serif" />
+
+    </LinearLayout>
+
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:cardBackgroundColor="@color/surface_card"
+        app:cardCornerRadius="24dp"
+        app:cardElevation="0dp"
+        app:strokeWidth="1dp"
+        app:strokeColor="@color/card_border_dim">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="20dp">
+
+            <LinearLayout
+                android:id="@+id/groupSelfEvalStatRows"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+
+            <TextView
+                android:id="@+id/textSelfEvalStatsEmpty"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="No check-ins yet — your subjective scale history appears here once you submit one."
+                android:textColor="@color/text_secondary"
+                android:textSize="13sp"
+                android:lineSpacingMultiplier="1.35"
+                android:visibility="gone" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnSelfEvalStatsOpen"
+                style="@style/Widget.Material3.Button.OutlinedButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="14dp"
+                android:text="📝 Update this week's check-in" />
+
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
+</LinearLayout>


### PR DESCRIPTION
## Summary

Two follow-ups on top of #49 that landed on the branch after merge:

1. **Subjective Scales card in the stats bottom sheet.** One row per cessation scale showing the latest weekly value, an ASCII sparkline of the last 4 entries (`5 → 6 → 7 → 8`), and a direction-only delta badge (`↑ +1` / `↓ −1` / `→ steady`). Period-agnostic — weekly cadence doesn't fit the Day/Week/Month/Year chips. Delta stays neutral colour because polarities differ across scales (↓ cough is desirable, ↓ smell isn't) and the manifesto says no moralising.
2. **Onboarding baseline capture.** New 4th onboarding page renders the six cessation-recovery scales as compact slider rows. Only sliders the user actually releases get persisted — matches the no-zero-fill rule used by the weekly carousel. Day-0 anchor for the digest sparkline, stats card delta, and the carousel's pre-fill.

## Test plan

- [x] `./gradlew assembleDebug` passes.
- [ ] Open stats sheet — Subjective Scales card renders with empty state initially; after the first carousel submission, rows appear with sparkline + value + delta.
- [ ] Fresh install onboarding — flow advances Welcome → Goal → Cig baseline → Self-eval baseline → Ready. Touching a slider on the new page persists that scale only.
- [ ] Skip onboarding without touching the self-eval sliders — `WeeklySelfEvalStore` has no entries; weekly carousel still defaults to 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)