### PR TITLE
Weekly self-eval check-in, onboarding baseline, and dedicated Stats screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,7 @@
 ## Workflow
 
 After completing a task, always commit, push, and deploy.
+
+## Design system
+
+Smokeless follows the [Bios Ecosystem Design System](../Bios/docs/DESIGN_SYSTEM.md). Identity palette = Electric Mint `#00E5A0` + Golden Hour amber `#FFB830`, dark mode. Don't invent new color roles or component anatomy — extend the canonical 14-role token set in [design-tokens/](../Bios/docs/design-tokens/).

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,10 @@
             android:label="Achievements"
             android:parentActivityName=".MainActivity" />
         <activity
+            android:name=".StatsActivity"
+            android:label="Stats"
+            android:parentActivityName=".MainActivity" />
+        <activity
             android:name=".HealthTimelineActivity"
             android:label="Healing timeline"
             android:parentActivityName=".MainActivity" />

--- a/app/src/main/java/com/smokless/smokeless/MainActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.smokless.smokeless
 
 import android.content.Intent
-import android.graphics.Color
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -10,29 +9,15 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.github.mikephil.charting.components.XAxis
-import com.github.mikephil.charting.data.BarData
-import com.github.mikephil.charting.data.BarDataSet
-import com.github.mikephil.charting.data.BarEntry
-import com.github.mikephil.charting.data.Entry
-import com.github.mikephil.charting.data.LineData
-import com.github.mikephil.charting.data.LineDataSet
-import com.github.mikephil.charting.formatter.IndexAxisValueFormatter
-import com.github.mikephil.charting.formatter.ValueFormatter
-import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.smokless.smokeless.data.entity.Substance
 import com.smokless.smokeless.databinding.ActivityMainBinding
-import com.smokless.smokeless.ui.main.ChartData
 import com.smokless.smokeless.ui.main.MainViewModel
 import com.smokless.smokeless.ui.main.RecoveryTimelineAdapter
-import com.smokless.smokeless.ui.main.ScoreAdapter
-import com.smokless.smokeless.ui.main.ScoreData
 import com.smokless.smokeless.util.HealthBenefits
 import com.smokless.smokeless.util.ScoreCalculator
 import com.smokless.smokeless.util.SubstanceCopy
 import com.smokless.smokeless.util.TimeFormatter
 import java.text.DecimalFormat
-import kotlin.math.min
 import kotlin.math.roundToInt
 
 class MainActivity : AppCompatActivity() {
@@ -40,9 +25,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
     private val viewModel: MainViewModel by viewModels()
 
-    private lateinit var statsAdapter: ScoreAdapter
     private val timelineAdapter = RecoveryTimelineAdapter()
-    private lateinit var statsSheet: BottomSheetBehavior<View>
 
     private val refreshHandler = Handler(Looper.getMainLooper())
 
@@ -55,7 +38,6 @@ class MainActivity : AppCompatActivity() {
         com.smokless.smokeless.bios.BiosClient.METRIC_SMOKER_IDENTITY_SELF_RATING to "Identity",
     )
 
-    private var currentPeriod = "month"
     private var copy: SubstanceCopy = SubstanceCopy.TOBACCO
 
     // Banked recovery is "paused" during the substance exposure window after a
@@ -88,12 +70,7 @@ class MainActivity : AppCompatActivity() {
 
         setupToolbar()
         setupTimeline()
-        setupStatsSheet()
-        setupStatsRecycler()
-        setupChipGroup()
-        setupCharts()
         setupFab()
-        setupCollapsibleSections()
         setupSwipeRefresh()
         observeViewModel()
     }
@@ -104,6 +81,10 @@ class MainActivity : AppCompatActivity() {
         }
         binding.toolbar.setOnMenuItemClickListener { menuItem ->
             when (menuItem.itemId) {
+                R.id.action_stats -> {
+                    startActivity(Intent(this, StatsActivity::class.java))
+                    true
+                }
                 R.id.action_achievements -> {
                     startActivity(Intent(this, AchievementsActivity::class.java))
                     true
@@ -116,349 +97,6 @@ class MainActivity : AppCompatActivity() {
     private fun setupTimeline() {
         binding.recyclerTimeline.layoutManager = LinearLayoutManager(this)
         binding.recyclerTimeline.adapter = timelineAdapter
-    }
-
-    private fun setupStatsSheet() {
-        statsSheet = BottomSheetBehavior.from(binding.statsSheet)
-        statsSheet.state = BottomSheetBehavior.STATE_COLLAPSED
-        binding.statsSheetHandle.setOnClickListener {
-            statsSheet.state =
-                if (statsSheet.state == BottomSheetBehavior.STATE_EXPANDED)
-                    BottomSheetBehavior.STATE_COLLAPSED
-                else
-                    BottomSheetBehavior.STATE_EXPANDED
-        }
-    }
-
-    private fun setupStatsRecycler() {
-        statsAdapter = ScoreAdapter()
-        binding.sectionStatistics.recyclerStats.layoutManager = LinearLayoutManager(this)
-        binding.sectionStatistics.recyclerStats.adapter = statsAdapter
-    }
-
-    private fun setupChipGroup() {
-        binding.sectionStatistics.chipGroupPeriod.setOnCheckedStateChangeListener { _, checkedIds ->
-            if (checkedIds.isEmpty()) return@setOnCheckedStateChangeListener
-
-            when (checkedIds[0]) {
-                R.id.chipToday -> {
-                    currentPeriod = "day"
-                    updatePeriodHeader("☀️", "Today")
-                }
-                R.id.chipWeek -> {
-                    currentPeriod = "week"
-                    updatePeriodHeader("📋", "This Week")
-                }
-                R.id.chipMonth -> {
-                    currentPeriod = "month"
-                    updatePeriodHeader("📆", "This Month")
-                }
-                R.id.chipYear -> {
-                    currentPeriod = "year"
-                    updatePeriodHeader("📅", "This Year")
-                }
-                R.id.chipAllTime -> {
-                    currentPeriod = "all"
-                    updatePeriodHeader("📊", "All Time")
-                }
-            }
-
-            val statsRecycler = binding.sectionStatistics.recyclerStats
-            val quickStats = binding.sectionQuickStats.root
-            statsRecycler.animate().alpha(0f).setDuration(150).withEndAction {
-                viewModel.setChartPeriod(currentPeriod)
-                updateStatsForPeriod()
-                updateChartLabels()
-
-                val scores = when (currentPeriod) {
-                    "day" -> viewModel.dayScores.value
-                    "week" -> viewModel.weekScores.value
-                    "month" -> viewModel.monthScores.value
-                    "year" -> viewModel.yearScores.value
-                    "all" -> viewModel.allTimeScores.value
-                    else -> null
-                }
-                scores?.let { updatePeriodCards(it) }
-
-                statsRecycler.animate().alpha(1f).setDuration(200).start()
-            }.start()
-            quickStats.animate().alpha(0f).setDuration(150).withEndAction {
-                quickStats.animate().alpha(1f).setDuration(200).setStartDelay(100).start()
-            }.start()
-        }
-
-        binding.sectionStatistics.chipMonth.isChecked = true
-    }
-
-    private fun updateChartLabels() {
-        binding.sectionCharts.textTrendChartTitle.text = when (currentPeriod) {
-            "day" -> "Hourly Trend"
-            "week" -> "Daily Trend"
-            "month" -> "7-Day Average Trend"
-            "year" -> "Monthly Trend"
-            "all" -> "Long-term Trend"
-            else -> "Trend"
-        }
-        binding.sectionCharts.textBarChartTitle.text = when (currentPeriod) {
-            "day" -> "Hourly Count"
-            else -> "Daily Count"
-        }
-    }
-
-    private fun updatePeriodHeader(icon: String, title: String) {
-        binding.sectionStatistics.textPeriodIcon.text = icon
-        binding.sectionStatistics.textPeriodTitle.text = title
-
-        binding.sectionQuickStats.textQuickStatsTitle.text = when (currentPeriod) {
-            "day" -> "Today's Highlights"
-            "week" -> "This Week's Highlights"
-            "month" -> "This Month's Highlights"
-            "year" -> "This Year's Highlights"
-            "all" -> "All-Time Highlights"
-            else -> "Period Highlights"
-        }
-        binding.sectionQuickStats.textBestTodayLabel.text = when (currentPeriod) {
-            "day" -> "Today's Streak"
-            "week" -> "Week Streak"
-            "month" -> "Month Streak"
-            "year" -> "Year Streak"
-            "all" -> "Best Streak"
-            else -> "Clean Streak"
-        }
-        binding.sectionQuickStats.textCountTodayLabel.text = when (currentPeriod) {
-            "day" -> "Today"
-            "week" -> "This Week"
-            "month" -> "This Month"
-            "year" -> "This Year"
-            "all" -> "All Time"
-            else -> "Total"
-        }
-    }
-
-    private fun updateStatsForPeriod() {
-        val scores: List<ScoreData>? = when (currentPeriod) {
-            "day" -> viewModel.dayScores.value
-            "week" -> viewModel.weekScores.value
-            "month" -> viewModel.monthScores.value
-            "year" -> viewModel.yearScores.value
-            "all" -> viewModel.allTimeScores.value
-            else -> null
-        }
-        scores?.let {
-            statsAdapter.setScores(it)
-            updatePeriodCount(it)
-        }
-    }
-
-    private fun updatePeriodCount(scores: List<ScoreData>) {
-        for (score in scores) {
-            if (score.type == ScoreData.StatType.COUNT) {
-                val count = score.value
-                binding.sectionStatistics.textPeriodCount.text = "$count ${copy.unitFor(count)}"
-                return
-            }
-        }
-        binding.sectionStatistics.textPeriodCount.text = "0 ${copy.units}"
-    }
-
-    private fun setupCharts() {
-        val barChart = binding.sectionCharts.barChart
-        barChart.setBackgroundColor(Color.TRANSPARENT)
-        barChart.description.isEnabled = false
-        barChart.setTouchEnabled(true)
-        barChart.isDragEnabled = true
-        barChart.setScaleEnabled(false)
-        barChart.setPinchZoom(false)
-        barChart.setDrawGridBackground(false)
-        barChart.legend.isEnabled = false
-        barChart.extraBottomOffset = 8f
-        barChart.setFitBars(true)
-        barChart.setNoDataText("Start tracking to see your patterns here")
-        barChart.setNoDataTextColor(ContextCompat.getColor(this, R.color.text_secondary))
-
-        val barXAxis = barChart.xAxis
-        barXAxis.position = XAxis.XAxisPosition.BOTTOM
-        barXAxis.setDrawGridLines(false)
-        barXAxis.textColor = ContextCompat.getColor(this, R.color.text_tertiary)
-        barXAxis.textSize = 10f
-        barXAxis.granularity = 1f
-        barXAxis.setAvoidFirstLastClipping(true)
-
-        val barLeftAxis = barChart.axisLeft
-        barLeftAxis.setDrawGridLines(true)
-        barLeftAxis.gridColor = ContextCompat.getColor(this, R.color.divider)
-        barLeftAxis.textColor = ContextCompat.getColor(this, R.color.text_tertiary)
-        barLeftAxis.textSize = 10f
-        barLeftAxis.axisMinimum = 0f
-        barLeftAxis.granularity = 1f
-        barLeftAxis.setDrawZeroLine(true)
-        barLeftAxis.zeroLineColor = ContextCompat.getColor(this, R.color.divider)
-        barChart.axisRight.isEnabled = false
-
-        val lineChart = binding.sectionCharts.lineChart
-        lineChart.setBackgroundColor(Color.TRANSPARENT)
-        lineChart.description.isEnabled = false
-        lineChart.setTouchEnabled(true)
-        lineChart.isDragEnabled = true
-        lineChart.setScaleEnabled(false)
-        lineChart.setPinchZoom(false)
-        lineChart.setDrawGridBackground(false)
-        lineChart.legend.isEnabled = false
-        lineChart.extraBottomOffset = 8f
-        lineChart.setNoDataText("Your progress trends will appear here")
-        lineChart.setNoDataTextColor(ContextCompat.getColor(this, R.color.text_secondary))
-
-        val lineXAxis = lineChart.xAxis
-        lineXAxis.position = XAxis.XAxisPosition.BOTTOM
-        lineXAxis.setDrawGridLines(false)
-        lineXAxis.textColor = ContextCompat.getColor(this, R.color.text_tertiary)
-        lineXAxis.textSize = 10f
-        lineXAxis.granularity = 1f
-        lineXAxis.setAvoidFirstLastClipping(true)
-
-        val lineLeftAxis = lineChart.axisLeft
-        lineLeftAxis.setDrawGridLines(true)
-        lineLeftAxis.gridColor = ContextCompat.getColor(this, R.color.divider)
-        lineLeftAxis.textColor = ContextCompat.getColor(this, R.color.text_tertiary)
-        lineLeftAxis.textSize = 10f
-        lineLeftAxis.axisMinimum = 0f
-        lineLeftAxis.granularity = 1f
-        lineLeftAxis.setDrawZeroLine(true)
-        lineLeftAxis.zeroLineColor = ContextCompat.getColor(this, R.color.divider)
-        lineChart.axisRight.isEnabled = false
-    }
-
-    private fun updateCharts(data: ChartData?) {
-        if (data == null) {
-            binding.sectionCharts.lineChart.clear()
-            binding.sectionCharts.lineChart.visibility = View.INVISIBLE
-            binding.sectionCharts.emptyStateTrend.visibility = View.VISIBLE
-            binding.sectionCharts.barChart.clear()
-            binding.sectionCharts.barChart.visibility = View.INVISIBLE
-            binding.sectionCharts.emptyStateBar.visibility = View.VISIBLE
-            binding.sectionCharts.textChartTrend.text = "No data yet"
-            binding.sectionCharts.textBarChartAvg.text = "Avg: 0/day"
-            return
-        }
-
-        binding.sectionCharts.lineChart.visibility = View.VISIBLE
-        binding.sectionCharts.emptyStateTrend.visibility = View.GONE
-        binding.sectionCharts.barChart.visibility = View.VISIBLE
-        binding.sectionCharts.emptyStateBar.visibility = View.GONE
-
-        val maxCount = data.dailyCounts.maxOrNull() ?: 0
-        val maxAverage = data.movingAverage.maxOrNull() ?: 0.0
-        val dataMaxValue = kotlin.math.max(maxCount.toFloat(), maxAverage.toFloat())
-        val chartMaxValue = kotlin.math.max(dataMaxValue * 1.2f, 5f)
-
-        val barEntries = data.dailyCounts.mapIndexed { index, count ->
-            BarEntry(index.toFloat(), count.toFloat())
-        }
-        if (barEntries.isNotEmpty()) {
-            binding.sectionCharts.barChart.visibility = View.VISIBLE
-            binding.sectionCharts.emptyStateBar.visibility = View.GONE
-            val barDataSet = BarDataSet(barEntries, "Cigarettes").apply {
-                color = ContextCompat.getColor(this@MainActivity, R.color.accent_amber)
-                setDrawValues(true)
-                valueTextColor = ContextCompat.getColor(this@MainActivity, R.color.text_secondary)
-                valueTextSize = 9f
-                valueFormatter = object : ValueFormatter() {
-                    override fun getFormattedValue(value: Float): String {
-                        return if (value > 0) value.toInt().toString() else ""
-                    }
-                }
-            }
-            val barData = BarData(barDataSet).apply { barWidth = 0.6f }
-            binding.sectionCharts.barChart.axisLeft.axisMaximum = kotlin.math.max(chartMaxValue, 1f)
-            binding.sectionCharts.barChart.xAxis.valueFormatter = IndexAxisValueFormatter(getLimitedLabels(data.labels))
-            binding.sectionCharts.barChart.xAxis.setLabelCount(getLimitedLabelCount(data.labels.size), false)
-            binding.sectionCharts.barChart.data = barData
-            binding.sectionCharts.barChart.invalidate()
-        } else {
-            binding.sectionCharts.barChart.visibility = View.INVISIBLE
-            binding.sectionCharts.emptyStateBar.visibility = View.VISIBLE
-        }
-
-        val avgLabel = when (currentPeriod) {
-            "day" -> "Total: ${data.dailyCounts.sum()}"
-            else -> String.format("Avg: %.1f/day", data.avgDailyCount)
-        }
-        binding.sectionCharts.textBarChartAvg.text = avgLabel
-
-        val lineEntries = data.movingAverage.mapIndexed { index, avg ->
-            Entry(index.toFloat(), avg.toFloat())
-        }
-        if (lineEntries.isNotEmpty()) {
-            binding.sectionCharts.lineChart.visibility = View.VISIBLE
-            binding.sectionCharts.emptyStateTrend.visibility = View.GONE
-            val lineDataSet = LineDataSet(lineEntries, "Trend").apply {
-                color = ContextCompat.getColor(this@MainActivity, R.color.accent_primary)
-                setCircleColor(ContextCompat.getColor(this@MainActivity, R.color.accent_primary))
-                lineWidth = 2.5f
-                circleRadius = 3f
-                setDrawCircleHole(true)
-                circleHoleRadius = 1.5f
-                circleHoleColor = ContextCompat.getColor(this@MainActivity, R.color.surface_card)
-                setDrawValues(false)
-                mode = LineDataSet.Mode.LINEAR
-                cubicIntensity = 0.1f
-                setDrawFilled(true)
-                fillColor = ContextCompat.getColor(this@MainActivity, R.color.accent_primary)
-                fillAlpha = 30
-            }
-            val lineData = LineData(lineDataSet)
-            binding.sectionCharts.lineChart.axisLeft.axisMaximum = kotlin.math.max(chartMaxValue, 1f)
-            binding.sectionCharts.lineChart.xAxis.valueFormatter = IndexAxisValueFormatter(getLimitedLabels(data.labels))
-            binding.sectionCharts.lineChart.xAxis.setLabelCount(getLimitedLabelCount(data.labels.size), false)
-            binding.sectionCharts.lineChart.data = lineData
-            binding.sectionCharts.lineChart.invalidate()
-        } else {
-            binding.sectionCharts.lineChart.visibility = View.INVISIBLE
-            binding.sectionCharts.emptyStateTrend.visibility = View.VISIBLE
-        }
-
-        updateTrendIndicator(data)
-    }
-
-    private fun getLimitedLabels(labels: List<String>): List<String> {
-        if (labels.size <= 15) return labels
-        val step = labels.size / 12
-        return labels.mapIndexed { index, label ->
-            if (index % step == 0 || index == labels.size - 1) label else ""
-        }
-    }
-
-    private fun getLimitedLabelCount(totalLabels: Int): Int = when {
-        totalLabels <= 7 -> totalLabels
-        totalLabels <= 15 -> 7
-        totalLabels <= 30 -> 10
-        else -> 12
-    }
-
-    private fun updateTrendIndicator(data: ChartData) {
-        val absChange = kotlin.math.abs(data.trendPercentage)
-        when {
-            data.isImproving && absChange >= 10 -> {
-                binding.sectionCharts.textChartTrend.text = String.format("↓ Down %.0f%%", absChange)
-                binding.sectionCharts.textChartTrend.setTextColor(ContextCompat.getColor(this, R.color.status_champion))
-            }
-            data.isImproving && absChange >= 5 -> {
-                binding.sectionCharts.textChartTrend.text = String.format("↓ Down %.0f%%", absChange)
-                binding.sectionCharts.textChartTrend.setTextColor(ContextCompat.getColor(this, R.color.status_strong))
-            }
-            absChange < 5 -> {
-                binding.sectionCharts.textChartTrend.text = "→ Stable"
-                binding.sectionCharts.textChartTrend.setTextColor(ContextCompat.getColor(this, R.color.status_steady))
-            }
-            !data.isImproving && absChange < 20 -> {
-                binding.sectionCharts.textChartTrend.text = String.format("↑ Up %.0f%%", absChange)
-                binding.sectionCharts.textChartTrend.setTextColor(ContextCompat.getColor(this, R.color.accent_amber))
-            }
-            else -> {
-                binding.sectionCharts.textChartTrend.text = String.format("↑ Up %.0f%%", absChange)
-                binding.sectionCharts.textChartTrend.setTextColor(ContextCompat.getColor(this, R.color.status_reset))
-            }
-        }
     }
 
     private fun setupFab() {
@@ -582,35 +220,6 @@ class MainActivity : AppCompatActivity() {
             .show()
     }
 
-    private fun setupCollapsibleSections() {
-        setupCollapsible(
-            binding.sectionCharts.headerCharts,
-            binding.sectionCharts.contentCharts,
-            binding.sectionCharts.chevronCharts
-        )
-        setupCollapsible(
-            binding.sectionRecords.headerRecords,
-            binding.sectionRecords.contentRecords,
-            binding.sectionRecords.chevronRecords
-        )
-    }
-
-    private fun setupCollapsible(header: View, content: View, chevron: android.widget.TextView) {
-        header.setOnClickListener {
-            if (content.visibility == View.GONE) {
-                content.visibility = View.VISIBLE
-                chevron.text = "▲"
-                content.alpha = 0f
-                content.animate().alpha(1f).setDuration(200).start()
-            } else {
-                content.animate().alpha(0f).setDuration(150).withEndAction {
-                    content.visibility = View.GONE
-                }.start()
-                chevron.text = "▼"
-            }
-        }
-    }
-
     private fun setupSwipeRefresh() {
         binding.swipeRefresh.setColorSchemeResources(R.color.accent_primary)
         binding.swipeRefresh.setProgressBackgroundColorSchemeResource(R.color.surface_card)
@@ -679,15 +288,10 @@ class MainActivity : AppCompatActivity() {
             if (timeSinceLastSmokeMs in 1 until pausedThresholdMs) View.VISIBLE else View.GONE
     }
 
-    private fun applySubstanceCopy() {
-        binding.sectionReductionTrend.textReductionUnit.text = copy.perDay
-    }
-
     private fun observeViewModel() {
         viewModel.primarySubstance.observe(this) { substance ->
             primarySubstance = substance
             copy = SubstanceCopy.forSubstance(substance)
-            applySubstanceCopy()
             // Substance change re-anchors the milestone list. Force a refresh
             // even when the achieved-count number is unchanged.
             lastAchievedCount = -1
@@ -700,54 +304,11 @@ class MainActivity : AppCompatActivity() {
             updateRecoveryHero(score)
         }
 
-        // Banked time no longer drives the hero — it surfaces in the records
-        // section and in the post-log snackbar instead.
-        viewModel.bankedSmokeFreeMs.observe(this) { ms ->
-            binding.sectionRecords.textBankedHours.text = TimeFormatter.formatShort(ms)
-        }
-
-        viewModel.allTimeScores.observe(this) { scores ->
-            if (currentPeriod == "all") {
-                statsAdapter.setScores(scores)
-                updatePeriodCount(scores)
-                updatePeriodCards(scores)
-            }
-            updateRecordCards(scores)
-        }
-        viewModel.yearScores.observe(this) { scores ->
-            if (currentPeriod == "year") {
-                statsAdapter.setScores(scores)
-                updatePeriodCount(scores)
-                updatePeriodCards(scores)
-            }
-        }
-        viewModel.monthScores.observe(this) { scores ->
-            if (currentPeriod == "month") {
-                statsAdapter.setScores(scores)
-                updatePeriodCount(scores)
-                updatePeriodCards(scores)
-            }
-        }
-        viewModel.weekScores.observe(this) { scores ->
-            if (currentPeriod == "week") {
-                statsAdapter.setScores(scores)
-                updatePeriodCount(scores)
-                updatePeriodCards(scores)
-            }
-        }
-        viewModel.dayScores.observe(this) { scores ->
-            if (currentPeriod == "day") {
-                statsAdapter.setScores(scores)
-                updatePeriodCount(scores)
-                updatePeriodCards(scores)
-            }
-        }
-
-        viewModel.chartData.observe(this) { data -> updateCharts(data) }
-
-        viewModel.moneySavedFormatted.observe(this) { formatted ->
-            binding.sectionRecords.textMoneySaved.text = formatted
-        }
+        // bankedSmokeFreeMs is still observed so the post-log snackbar can
+        // report the user's smoke-free balance, even though the records card
+        // (which used to render it on the home screen) now lives in
+        // StatsActivity.
+        viewModel.bankedSmokeFreeMs.observe(this) { /* snackbar reads .value */ }
 
         // perSubstancePace drives the hero verdict block: one chip per
         // substance the user logs (just one for single-substance users,
@@ -757,7 +318,6 @@ class MainActivity : AppCompatActivity() {
         // misleading for multi-substance users.
         viewModel.perSubstancePace.observe(this) { entries -> updateHeroPace(entries) }
 
-        viewModel.reductionStats.observe(this) { stats -> updateReductionTrend(stats) }
         viewModel.firstSmokeOfDay.observe(this) { fs -> updateFirstSmokeOfDay(fs) }
         viewModel.substanceLevels.observe(this) { levels -> updateSubstanceLevels(levels) }
         viewModel.triggerWindows.observe(this) { windows -> updateTriggerWindows(windows) }
@@ -1134,101 +694,6 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun updateReductionTrend(stats: com.smokless.smokeless.util.ScoreCalculator.ReductionStats) {
-        val avgFormat = DecimalFormat("0.#")
-        binding.sectionReductionTrend.textReductionAverage.text = avgFormat.format(stats.rollingAverage7d)
-
-        val coverage = stats.loggedDaysLast7
-        if (stats.hasEnoughData && coverage in 1..6) {
-            binding.sectionReductionTrend.textReductionCoverage.text = "across $coverage of 7 days logged"
-            binding.sectionReductionTrend.textReductionCoverage.visibility = View.VISIBLE
-        } else {
-            binding.sectionReductionTrend.textReductionCoverage.visibility = View.GONE
-        }
-
-        val velocityText = when {
-            !stats.hasEnoughData -> "Logging — trend appears with more days of data"
-            !stats.velocityComparable ->
-                "Recent activity logged — comparison resumes after continuous tracking"
-            stats.velocityPercent >= 5.0 ->
-                "${DecimalFormat("0").format(stats.velocityPercent)}% less than 30 days ago"
-            stats.velocityPercent <= -5.0 ->
-                "${DecimalFormat("0").format(-stats.velocityPercent)}% more than 30 days ago"
-            else -> "Steady vs. 30 days ago"
-        }
-        binding.sectionReductionTrend.textReductionVelocity.text = velocityText
-    }
-
-    private fun updatePeriodCards(scores: List<ScoreData>?) {
-        if (scores.isNullOrEmpty()) {
-            binding.sectionQuickStats.textBestTodayValue.text = "0d"
-            binding.sectionQuickStats.textCountTodayValue.text = "0"
-            binding.sectionQuickStats.progressBestToday.progress = 0
-            binding.sectionQuickStats.progressCountToday.progress = 0
-            return
-        }
-        for (score in scores) {
-            when (score.type) {
-                ScoreData.StatType.STREAK -> if (score.label.contains("Current")) {
-                    val displayValue = when (currentPeriod) {
-                        "day" -> if (score.value >= 1L) "${score.value}d" else "${score.value}h"
-                        else -> "${score.value}d"
-                    }
-                    binding.sectionQuickStats.textBestTodayValue.text = displayValue
-                    binding.sectionQuickStats.progressBestToday.progress =
-                        min(score.percentage, 100.0).toInt()
-                    val colorRes = when {
-                        score.value >= 30L -> R.color.status_champion
-                        score.value >= 7L -> R.color.status_strong
-                        score.value >= 3L -> R.color.accent_teal
-                        score.value >= 1L -> R.color.status_building
-                        else -> R.color.status_reset
-                    }
-                    binding.sectionQuickStats.progressBestToday.setIndicatorColor(
-                        ContextCompat.getColor(this, colorRes)
-                    )
-                }
-                ScoreData.StatType.COUNT -> {
-                    val displayValue = when {
-                        score.value == 0L -> "0 🎉"
-                        score.value == 1L -> "1"
-                        else -> score.value.toString()
-                    }
-                    binding.sectionQuickStats.textCountTodayValue.text = displayValue
-                    binding.sectionQuickStats.progressCountToday.progress =
-                        min(score.percentage, 100.0).toInt()
-                    val colorRes = when {
-                        score.value == 0L -> R.color.status_champion
-                        score.value <= 2L -> R.color.status_strong
-                        score.value <= 5L -> R.color.accent_teal
-                        score.value <= 10L -> R.color.status_building
-                        score.value <= 15L -> R.color.accent_amber
-                        else -> R.color.status_reset
-                    }
-                    binding.sectionQuickStats.progressCountToday.setIndicatorColor(
-                        ContextCompat.getColor(this, colorRes)
-                    )
-                }
-                else -> {}
-            }
-        }
-    }
-
-    private fun updateRecordCards(scores: List<ScoreData>?) {
-        if (scores.isNullOrEmpty()) return
-        for (score in scores) {
-            when (score.type) {
-                ScoreData.StatType.STREAK -> if (score.label.contains("Best")) {
-                    binding.sectionRecords.textAllTimeBest.text = "${score.value} days"
-                }
-                ScoreData.StatType.COUNT -> {
-                    binding.sectionRecords.textTotalSessions.text = score.value.toString()
-                }
-                else -> {}
-            }
-        }
-    }
-
     override fun onResume() {
         super.onResume()
         viewModel.refreshData()
@@ -1236,71 +701,6 @@ class MainActivity : AppCompatActivity() {
         // Idempotent — schedules only when the alarm hasn't been set yet.
         com.smokless.smokeless.util.TriggerWindowReceiver.schedule(this)
         com.smokless.smokeless.util.WeeklyDigestReceiver.schedule(this)
-        updateSelfEvalStats()
-    }
-
-    /**
-     * Renders the "Subjective Scales" stats card — latest weekly value per
-     * metric plus the delta against the prior entry. Period-agnostic (the
-     * scales are captured weekly, so the period-chip framing doesn't apply).
-     * Tap the CTA → opens the carousel to update this week's check-in.
-     */
-    private fun updateSelfEvalStats() {
-        val sectionRoot = binding.sectionSelfEvalStats.root
-        val rowsGroup = sectionRoot.findViewById<android.widget.LinearLayout>(R.id.groupSelfEvalStatRows)
-        val empty = sectionRoot.findViewById<android.widget.TextView>(R.id.textSelfEvalStatsEmpty)
-        val openBtn = sectionRoot.findViewById<com.google.android.material.button.MaterialButton>(R.id.btnSelfEvalStatsOpen)
-        val store = com.smokless.smokeless.util.WeeklySelfEvalStore(applicationContext)
-        val inflater = layoutInflater
-        val numFmt = DecimalFormat("0.#")
-
-        rowsGroup.removeAllViews()
-        var anyRendered = false
-        for ((key, label) in SELF_EVAL_DIGEST_LABELS) {
-            val recent = store.recent(key, limit = 4)
-            if (recent.isEmpty()) continue
-            anyRendered = true
-
-            val row = inflater.inflate(R.layout.item_self_eval_stat_row, rowsGroup, false)
-            val labelView = row.findViewById<android.widget.TextView>(R.id.textStatRowLabel)
-            val sparklineView = row.findViewById<android.widget.TextView>(R.id.textStatRowSparkline)
-            val valueView = row.findViewById<android.widget.TextView>(R.id.textStatRowValue)
-            val deltaView = row.findViewById<android.widget.TextView>(R.id.textStatRowDelta)
-
-            labelView.text = label
-            val latest = recent.first()
-            valueView.text = numFmt.format(latest.value)
-
-            if (recent.size >= 2) {
-                val prior = recent[1]
-                val delta = latest.value - prior.value
-                val absStr = numFmt.format(kotlin.math.abs(delta))
-                // Direction-only badge — "no judgment" per the cessation
-                // manifesto. Polarities differ across these scales (↓ cough
-                // is desirable, ↓ smell isn't), so the owner reads the
-                // direction; the app doesn't moralise.
-                val badge = when {
-                    kotlin.math.abs(delta) < 0.5 -> "→ steady"
-                    delta > 0 -> "↑ +$absStr"
-                    else -> "↓ −$absStr"
-                }
-                deltaView.text = badge
-                deltaView.setTextColor(ContextCompat.getColor(this, R.color.text_secondary))
-                deltaView.visibility = View.VISIBLE
-            } else {
-                deltaView.visibility = View.GONE
-            }
-
-            // Oldest → newest sparkline so the trend reads left-to-right.
-            val ordered = recent.reversed()
-            sparklineView.text = ordered.joinToString(" → ") { numFmt.format(it.value) }
-
-            rowsGroup.addView(row)
-        }
-        empty.visibility = if (anyRendered) View.GONE else View.VISIBLE
-        openBtn.setOnClickListener {
-            startActivity(Intent(this, WeeklySelfEvalActivity::class.java))
-        }
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/smokless/smokeless/StatsActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/StatsActivity.kt
@@ -1,0 +1,651 @@
+package com.smokless.smokeless
+
+import android.content.Intent
+import android.graphics.Color
+import android.os.Bundle
+import android.view.View
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.github.mikephil.charting.components.XAxis
+import com.github.mikephil.charting.data.BarData
+import com.github.mikephil.charting.data.BarDataSet
+import com.github.mikephil.charting.data.BarEntry
+import com.github.mikephil.charting.data.Entry
+import com.github.mikephil.charting.data.LineData
+import com.github.mikephil.charting.data.LineDataSet
+import com.github.mikephil.charting.formatter.IndexAxisValueFormatter
+import com.github.mikephil.charting.formatter.ValueFormatter
+import com.smokless.smokeless.databinding.ActivityStatsBinding
+import com.smokless.smokeless.ui.main.ChartData
+import com.smokless.smokeless.ui.main.MainViewModel
+import com.smokless.smokeless.ui.main.ScoreAdapter
+import com.smokless.smokeless.ui.main.ScoreData
+import com.smokless.smokeless.util.SubstanceCopy
+import com.smokless.smokeless.util.TimeFormatter
+import java.text.DecimalFormat
+import kotlin.math.min
+
+/**
+ * Dedicated stats surface. Mirrors the Bios pattern of a Scaffold-style
+ * dashboard (toolbar with back arrow + scrollable card stack) instead of
+ * burying the same content in a bottom sheet on the main screen.
+ */
+class StatsActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityStatsBinding
+    private val viewModel: MainViewModel by viewModels()
+    private lateinit var statsAdapter: ScoreAdapter
+
+    private val SELF_EVAL_DIGEST_LABELS: List<Pair<String, String>> = listOf(
+        com.smokless.smokeless.bios.BiosClient.METRIC_SMELL_SELF_RATING to "Smell",
+        com.smokless.smokeless.bios.BiosClient.METRIC_TASTE_SELF_RATING to "Taste",
+        com.smokless.smokeless.bios.BiosClient.METRIC_COUGH_FREQUENCY_SELF_RATING to "Cough",
+        com.smokless.smokeless.bios.BiosClient.METRIC_SPUTUM_SELF_RATING to "Sputum",
+        com.smokless.smokeless.bios.BiosClient.METRIC_BREATH_EASE_SELF_RATING to "Breath",
+        com.smokless.smokeless.bios.BiosClient.METRIC_SMOKER_IDENTITY_SELF_RATING to "Identity",
+    )
+
+    private var currentPeriod = "month"
+    private var copy: SubstanceCopy = SubstanceCopy.TOBACCO
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityStatsBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        binding.toolbar.setNavigationOnClickListener { finish() }
+
+        setupStatsRecycler()
+        setupChipGroup()
+        setupCharts()
+        setupCollapsibleSections()
+        observeViewModel()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.refreshData()
+        updateSelfEvalStats()
+    }
+
+    private fun setupStatsRecycler() {
+        statsAdapter = ScoreAdapter()
+        binding.sectionStatistics.recyclerStats.layoutManager = LinearLayoutManager(this)
+        binding.sectionStatistics.recyclerStats.adapter = statsAdapter
+    }
+
+    private fun setupChipGroup() {
+        binding.sectionStatistics.chipGroupPeriod.setOnCheckedStateChangeListener { _, checkedIds ->
+            if (checkedIds.isEmpty()) return@setOnCheckedStateChangeListener
+
+            when (checkedIds[0]) {
+                R.id.chipToday -> {
+                    currentPeriod = "day"
+                    updatePeriodHeader("☀️", "Today")
+                }
+                R.id.chipWeek -> {
+                    currentPeriod = "week"
+                    updatePeriodHeader("📋", "This Week")
+                }
+                R.id.chipMonth -> {
+                    currentPeriod = "month"
+                    updatePeriodHeader("📆", "This Month")
+                }
+                R.id.chipYear -> {
+                    currentPeriod = "year"
+                    updatePeriodHeader("📅", "This Year")
+                }
+                R.id.chipAllTime -> {
+                    currentPeriod = "all"
+                    updatePeriodHeader("📊", "All Time")
+                }
+            }
+
+            val statsRecycler = binding.sectionStatistics.recyclerStats
+            val quickStats = binding.sectionQuickStats.root
+            statsRecycler.animate().alpha(0f).setDuration(150).withEndAction {
+                viewModel.setChartPeriod(currentPeriod)
+                updateStatsForPeriod()
+                updateChartLabels()
+
+                val scores = when (currentPeriod) {
+                    "day" -> viewModel.dayScores.value
+                    "week" -> viewModel.weekScores.value
+                    "month" -> viewModel.monthScores.value
+                    "year" -> viewModel.yearScores.value
+                    "all" -> viewModel.allTimeScores.value
+                    else -> null
+                }
+                scores?.let { updatePeriodCards(it) }
+
+                statsRecycler.animate().alpha(1f).setDuration(200).start()
+            }.start()
+            quickStats.animate().alpha(0f).setDuration(150).withEndAction {
+                quickStats.animate().alpha(1f).setDuration(200).setStartDelay(100).start()
+            }.start()
+        }
+
+        binding.sectionStatistics.chipMonth.isChecked = true
+    }
+
+    private fun updateChartLabels() {
+        binding.sectionCharts.textTrendChartTitle.text = when (currentPeriod) {
+            "day" -> "Hourly Trend"
+            "week" -> "Daily Trend"
+            "month" -> "7-Day Average Trend"
+            "year" -> "Monthly Trend"
+            "all" -> "Long-term Trend"
+            else -> "Trend"
+        }
+        binding.sectionCharts.textBarChartTitle.text = when (currentPeriod) {
+            "day" -> "Hourly Count"
+            else -> "Daily Count"
+        }
+    }
+
+    private fun updatePeriodHeader(icon: String, title: String) {
+        binding.sectionStatistics.textPeriodIcon.text = icon
+        binding.sectionStatistics.textPeriodTitle.text = title
+
+        binding.sectionQuickStats.textQuickStatsTitle.text = when (currentPeriod) {
+            "day" -> "Today's Highlights"
+            "week" -> "This Week's Highlights"
+            "month" -> "This Month's Highlights"
+            "year" -> "This Year's Highlights"
+            "all" -> "All-Time Highlights"
+            else -> "Period Highlights"
+        }
+        binding.sectionQuickStats.textBestTodayLabel.text = when (currentPeriod) {
+            "day" -> "Today's Streak"
+            "week" -> "Week Streak"
+            "month" -> "Month Streak"
+            "year" -> "Year Streak"
+            "all" -> "Best Streak"
+            else -> "Clean Streak"
+        }
+        binding.sectionQuickStats.textCountTodayLabel.text = when (currentPeriod) {
+            "day" -> "Today"
+            "week" -> "This Week"
+            "month" -> "This Month"
+            "year" -> "This Year"
+            "all" -> "All Time"
+            else -> "Total"
+        }
+    }
+
+    private fun updateStatsForPeriod() {
+        val scores: List<ScoreData>? = when (currentPeriod) {
+            "day" -> viewModel.dayScores.value
+            "week" -> viewModel.weekScores.value
+            "month" -> viewModel.monthScores.value
+            "year" -> viewModel.yearScores.value
+            "all" -> viewModel.allTimeScores.value
+            else -> null
+        }
+        scores?.let {
+            statsAdapter.setScores(it)
+            updatePeriodCount(it)
+        }
+    }
+
+    private fun updatePeriodCount(scores: List<ScoreData>) {
+        for (score in scores) {
+            if (score.type == ScoreData.StatType.COUNT) {
+                val count = score.value
+                binding.sectionStatistics.textPeriodCount.text = "$count ${copy.unitFor(count)}"
+                return
+            }
+        }
+        binding.sectionStatistics.textPeriodCount.text = "0 ${copy.units}"
+    }
+
+    private fun setupCharts() {
+        val barChart = binding.sectionCharts.barChart
+        barChart.setBackgroundColor(Color.TRANSPARENT)
+        barChart.description.isEnabled = false
+        barChart.setTouchEnabled(true)
+        barChart.isDragEnabled = true
+        barChart.setScaleEnabled(false)
+        barChart.setPinchZoom(false)
+        barChart.setDrawGridBackground(false)
+        barChart.legend.isEnabled = false
+        barChart.extraBottomOffset = 8f
+        barChart.setFitBars(true)
+        barChart.setNoDataText("Start tracking to see your patterns here")
+        barChart.setNoDataTextColor(ContextCompat.getColor(this, R.color.text_secondary))
+
+        val barXAxis = barChart.xAxis
+        barXAxis.position = XAxis.XAxisPosition.BOTTOM
+        barXAxis.setDrawGridLines(false)
+        barXAxis.textColor = ContextCompat.getColor(this, R.color.text_tertiary)
+        barXAxis.textSize = 10f
+        barXAxis.granularity = 1f
+        barXAxis.setAvoidFirstLastClipping(true)
+
+        val barLeftAxis = barChart.axisLeft
+        barLeftAxis.setDrawGridLines(true)
+        barLeftAxis.gridColor = ContextCompat.getColor(this, R.color.divider)
+        barLeftAxis.textColor = ContextCompat.getColor(this, R.color.text_tertiary)
+        barLeftAxis.textSize = 10f
+        barLeftAxis.axisMinimum = 0f
+        barLeftAxis.granularity = 1f
+        barLeftAxis.setDrawZeroLine(true)
+        barLeftAxis.zeroLineColor = ContextCompat.getColor(this, R.color.divider)
+        barChart.axisRight.isEnabled = false
+
+        val lineChart = binding.sectionCharts.lineChart
+        lineChart.setBackgroundColor(Color.TRANSPARENT)
+        lineChart.description.isEnabled = false
+        lineChart.setTouchEnabled(true)
+        lineChart.isDragEnabled = true
+        lineChart.setScaleEnabled(false)
+        lineChart.setPinchZoom(false)
+        lineChart.setDrawGridBackground(false)
+        lineChart.legend.isEnabled = false
+        lineChart.extraBottomOffset = 8f
+        lineChart.setNoDataText("Your progress trends will appear here")
+        lineChart.setNoDataTextColor(ContextCompat.getColor(this, R.color.text_secondary))
+
+        val lineXAxis = lineChart.xAxis
+        lineXAxis.position = XAxis.XAxisPosition.BOTTOM
+        lineXAxis.setDrawGridLines(false)
+        lineXAxis.textColor = ContextCompat.getColor(this, R.color.text_tertiary)
+        lineXAxis.textSize = 10f
+        lineXAxis.granularity = 1f
+        lineXAxis.setAvoidFirstLastClipping(true)
+
+        val lineLeftAxis = lineChart.axisLeft
+        lineLeftAxis.setDrawGridLines(true)
+        lineLeftAxis.gridColor = ContextCompat.getColor(this, R.color.divider)
+        lineLeftAxis.textColor = ContextCompat.getColor(this, R.color.text_tertiary)
+        lineLeftAxis.textSize = 10f
+        lineLeftAxis.axisMinimum = 0f
+        lineLeftAxis.granularity = 1f
+        lineLeftAxis.setDrawZeroLine(true)
+        lineLeftAxis.zeroLineColor = ContextCompat.getColor(this, R.color.divider)
+        lineChart.axisRight.isEnabled = false
+    }
+
+    private fun updateCharts(data: ChartData?) {
+        if (data == null) {
+            binding.sectionCharts.lineChart.clear()
+            binding.sectionCharts.lineChart.visibility = View.INVISIBLE
+            binding.sectionCharts.emptyStateTrend.visibility = View.VISIBLE
+            binding.sectionCharts.barChart.clear()
+            binding.sectionCharts.barChart.visibility = View.INVISIBLE
+            binding.sectionCharts.emptyStateBar.visibility = View.VISIBLE
+            binding.sectionCharts.textChartTrend.text = "No data yet"
+            binding.sectionCharts.textBarChartAvg.text = "Avg: 0/day"
+            return
+        }
+
+        binding.sectionCharts.lineChart.visibility = View.VISIBLE
+        binding.sectionCharts.emptyStateTrend.visibility = View.GONE
+        binding.sectionCharts.barChart.visibility = View.VISIBLE
+        binding.sectionCharts.emptyStateBar.visibility = View.GONE
+
+        val maxCount = data.dailyCounts.maxOrNull() ?: 0
+        val maxAverage = data.movingAverage.maxOrNull() ?: 0.0
+        val dataMaxValue = kotlin.math.max(maxCount.toFloat(), maxAverage.toFloat())
+        val chartMaxValue = kotlin.math.max(dataMaxValue * 1.2f, 5f)
+
+        val barEntries = data.dailyCounts.mapIndexed { index, count ->
+            BarEntry(index.toFloat(), count.toFloat())
+        }
+        if (barEntries.isNotEmpty()) {
+            binding.sectionCharts.barChart.visibility = View.VISIBLE
+            binding.sectionCharts.emptyStateBar.visibility = View.GONE
+            val barDataSet = BarDataSet(barEntries, "Cigarettes").apply {
+                color = ContextCompat.getColor(this@StatsActivity, R.color.accent_amber)
+                setDrawValues(true)
+                valueTextColor = ContextCompat.getColor(this@StatsActivity, R.color.text_secondary)
+                valueTextSize = 9f
+                valueFormatter = object : ValueFormatter() {
+                    override fun getFormattedValue(value: Float): String {
+                        return if (value > 0) value.toInt().toString() else ""
+                    }
+                }
+            }
+            val barData = BarData(barDataSet).apply { barWidth = 0.6f }
+            binding.sectionCharts.barChart.axisLeft.axisMaximum = kotlin.math.max(chartMaxValue, 1f)
+            binding.sectionCharts.barChart.xAxis.valueFormatter = IndexAxisValueFormatter(getLimitedLabels(data.labels))
+            binding.sectionCharts.barChart.xAxis.setLabelCount(getLimitedLabelCount(data.labels.size), false)
+            binding.sectionCharts.barChart.data = barData
+            binding.sectionCharts.barChart.invalidate()
+        } else {
+            binding.sectionCharts.barChart.visibility = View.INVISIBLE
+            binding.sectionCharts.emptyStateBar.visibility = View.VISIBLE
+        }
+
+        val avgLabel = when (currentPeriod) {
+            "day" -> "Total: ${data.dailyCounts.sum()}"
+            else -> String.format("Avg: %.1f/day", data.avgDailyCount)
+        }
+        binding.sectionCharts.textBarChartAvg.text = avgLabel
+
+        val lineEntries = data.movingAverage.mapIndexed { index, avg ->
+            Entry(index.toFloat(), avg.toFloat())
+        }
+        if (lineEntries.isNotEmpty()) {
+            binding.sectionCharts.lineChart.visibility = View.VISIBLE
+            binding.sectionCharts.emptyStateTrend.visibility = View.GONE
+            val lineDataSet = LineDataSet(lineEntries, "Trend").apply {
+                color = ContextCompat.getColor(this@StatsActivity, R.color.accent_primary)
+                setCircleColor(ContextCompat.getColor(this@StatsActivity, R.color.accent_primary))
+                lineWidth = 2.5f
+                circleRadius = 3f
+                setDrawCircleHole(true)
+                circleHoleRadius = 1.5f
+                circleHoleColor = ContextCompat.getColor(this@StatsActivity, R.color.surface_card)
+                setDrawValues(false)
+                mode = LineDataSet.Mode.LINEAR
+                cubicIntensity = 0.1f
+                setDrawFilled(true)
+                fillColor = ContextCompat.getColor(this@StatsActivity, R.color.accent_primary)
+                fillAlpha = 30
+            }
+            val lineData = LineData(lineDataSet)
+            binding.sectionCharts.lineChart.axisLeft.axisMaximum = kotlin.math.max(chartMaxValue, 1f)
+            binding.sectionCharts.lineChart.xAxis.valueFormatter = IndexAxisValueFormatter(getLimitedLabels(data.labels))
+            binding.sectionCharts.lineChart.xAxis.setLabelCount(getLimitedLabelCount(data.labels.size), false)
+            binding.sectionCharts.lineChart.data = lineData
+            binding.sectionCharts.lineChart.invalidate()
+        } else {
+            binding.sectionCharts.lineChart.visibility = View.INVISIBLE
+            binding.sectionCharts.emptyStateTrend.visibility = View.VISIBLE
+        }
+
+        updateTrendIndicator(data)
+    }
+
+    private fun getLimitedLabels(labels: List<String>): List<String> {
+        if (labels.size <= 15) return labels
+        val step = labels.size / 12
+        return labels.mapIndexed { index, label ->
+            if (index % step == 0 || index == labels.size - 1) label else ""
+        }
+    }
+
+    private fun getLimitedLabelCount(totalLabels: Int): Int = when {
+        totalLabels <= 7 -> totalLabels
+        totalLabels <= 15 -> 7
+        totalLabels <= 30 -> 10
+        else -> 12
+    }
+
+    private fun updateTrendIndicator(data: ChartData) {
+        val absChange = kotlin.math.abs(data.trendPercentage)
+        when {
+            data.isImproving && absChange >= 10 -> {
+                binding.sectionCharts.textChartTrend.text = String.format("↓ Down %.0f%%", absChange)
+                binding.sectionCharts.textChartTrend.setTextColor(ContextCompat.getColor(this, R.color.status_champion))
+            }
+            data.isImproving && absChange >= 5 -> {
+                binding.sectionCharts.textChartTrend.text = String.format("↓ Down %.0f%%", absChange)
+                binding.sectionCharts.textChartTrend.setTextColor(ContextCompat.getColor(this, R.color.status_strong))
+            }
+            absChange < 5 -> {
+                binding.sectionCharts.textChartTrend.text = "→ Stable"
+                binding.sectionCharts.textChartTrend.setTextColor(ContextCompat.getColor(this, R.color.status_steady))
+            }
+            !data.isImproving && absChange < 20 -> {
+                binding.sectionCharts.textChartTrend.text = String.format("↑ Up %.0f%%", absChange)
+                binding.sectionCharts.textChartTrend.setTextColor(ContextCompat.getColor(this, R.color.accent_amber))
+            }
+            else -> {
+                binding.sectionCharts.textChartTrend.text = String.format("↑ Up %.0f%%", absChange)
+                binding.sectionCharts.textChartTrend.setTextColor(ContextCompat.getColor(this, R.color.status_reset))
+            }
+        }
+    }
+
+    private fun setupCollapsibleSections() {
+        setupCollapsible(
+            binding.sectionCharts.headerCharts,
+            binding.sectionCharts.contentCharts,
+            binding.sectionCharts.chevronCharts
+        )
+        setupCollapsible(
+            binding.sectionRecords.headerRecords,
+            binding.sectionRecords.contentRecords,
+            binding.sectionRecords.chevronRecords
+        )
+    }
+
+    private fun setupCollapsible(header: View, content: View, chevron: android.widget.TextView) {
+        header.setOnClickListener {
+            if (content.visibility == View.GONE) {
+                content.visibility = View.VISIBLE
+                chevron.text = "▲"
+                content.alpha = 0f
+                content.animate().alpha(1f).setDuration(200).start()
+            } else {
+                content.animate().alpha(0f).setDuration(150).withEndAction {
+                    content.visibility = View.GONE
+                }.start()
+                chevron.text = "▼"
+            }
+        }
+    }
+
+    private fun applySubstanceCopy() {
+        binding.sectionReductionTrend.textReductionUnit.text = copy.perDay
+    }
+
+    private fun observeViewModel() {
+        viewModel.primarySubstance.observe(this) { substance ->
+            copy = SubstanceCopy.forSubstance(substance)
+            applySubstanceCopy()
+        }
+
+        viewModel.bankedSmokeFreeMs.observe(this) { ms ->
+            binding.sectionRecords.textBankedHours.text = TimeFormatter.formatShort(ms)
+        }
+
+        viewModel.allTimeScores.observe(this) { scores ->
+            if (currentPeriod == "all") {
+                statsAdapter.setScores(scores)
+                updatePeriodCount(scores)
+                updatePeriodCards(scores)
+            }
+            updateRecordCards(scores)
+        }
+        viewModel.yearScores.observe(this) { scores ->
+            if (currentPeriod == "year") {
+                statsAdapter.setScores(scores)
+                updatePeriodCount(scores)
+                updatePeriodCards(scores)
+            }
+        }
+        viewModel.monthScores.observe(this) { scores ->
+            if (currentPeriod == "month") {
+                statsAdapter.setScores(scores)
+                updatePeriodCount(scores)
+                updatePeriodCards(scores)
+            }
+        }
+        viewModel.weekScores.observe(this) { scores ->
+            if (currentPeriod == "week") {
+                statsAdapter.setScores(scores)
+                updatePeriodCount(scores)
+                updatePeriodCards(scores)
+            }
+        }
+        viewModel.dayScores.observe(this) { scores ->
+            if (currentPeriod == "day") {
+                statsAdapter.setScores(scores)
+                updatePeriodCount(scores)
+                updatePeriodCards(scores)
+            }
+        }
+
+        viewModel.chartData.observe(this) { data -> updateCharts(data) }
+
+        viewModel.moneySavedFormatted.observe(this) { formatted ->
+            binding.sectionRecords.textMoneySaved.text = formatted
+        }
+
+        viewModel.reductionStats.observe(this) { stats -> updateReductionTrend(stats) }
+    }
+
+    private fun updateReductionTrend(stats: com.smokless.smokeless.util.ScoreCalculator.ReductionStats) {
+        val avgFormat = DecimalFormat("0.#")
+        binding.sectionReductionTrend.textReductionAverage.text = avgFormat.format(stats.rollingAverage7d)
+
+        val coverage = stats.loggedDaysLast7
+        if (stats.hasEnoughData && coverage in 1..6) {
+            binding.sectionReductionTrend.textReductionCoverage.text = "across $coverage of 7 days logged"
+            binding.sectionReductionTrend.textReductionCoverage.visibility = View.VISIBLE
+        } else {
+            binding.sectionReductionTrend.textReductionCoverage.visibility = View.GONE
+        }
+
+        val velocityText = when {
+            !stats.hasEnoughData -> "Logging — trend appears with more days of data"
+            !stats.velocityComparable ->
+                "Recent activity logged — comparison resumes after continuous tracking"
+            stats.velocityPercent >= 5.0 ->
+                "${DecimalFormat("0").format(stats.velocityPercent)}% less than 30 days ago"
+            stats.velocityPercent <= -5.0 ->
+                "${DecimalFormat("0").format(-stats.velocityPercent)}% more than 30 days ago"
+            else -> "Steady vs. 30 days ago"
+        }
+        binding.sectionReductionTrend.textReductionVelocity.text = velocityText
+    }
+
+    private fun updatePeriodCards(scores: List<ScoreData>?) {
+        if (scores.isNullOrEmpty()) {
+            binding.sectionQuickStats.textBestTodayValue.text = "0d"
+            binding.sectionQuickStats.textCountTodayValue.text = "0"
+            binding.sectionQuickStats.progressBestToday.progress = 0
+            binding.sectionQuickStats.progressCountToday.progress = 0
+            return
+        }
+        for (score in scores) {
+            when (score.type) {
+                ScoreData.StatType.STREAK -> if (score.label.contains("Current")) {
+                    val displayValue = when (currentPeriod) {
+                        "day" -> if (score.value >= 1L) "${score.value}d" else "${score.value}h"
+                        else -> "${score.value}d"
+                    }
+                    binding.sectionQuickStats.textBestTodayValue.text = displayValue
+                    binding.sectionQuickStats.progressBestToday.progress =
+                        min(score.percentage, 100.0).toInt()
+                    val colorRes = when {
+                        score.value >= 30L -> R.color.status_champion
+                        score.value >= 7L -> R.color.status_strong
+                        score.value >= 3L -> R.color.accent_teal
+                        score.value >= 1L -> R.color.status_building
+                        else -> R.color.status_reset
+                    }
+                    binding.sectionQuickStats.progressBestToday.setIndicatorColor(
+                        ContextCompat.getColor(this, colorRes)
+                    )
+                }
+                ScoreData.StatType.COUNT -> {
+                    val displayValue = when {
+                        score.value == 0L -> "0 🎉"
+                        score.value == 1L -> "1"
+                        else -> score.value.toString()
+                    }
+                    binding.sectionQuickStats.textCountTodayValue.text = displayValue
+                    binding.sectionQuickStats.progressCountToday.progress =
+                        min(score.percentage, 100.0).toInt()
+                    val colorRes = when {
+                        score.value == 0L -> R.color.status_champion
+                        score.value <= 2L -> R.color.status_strong
+                        score.value <= 5L -> R.color.accent_teal
+                        score.value <= 10L -> R.color.status_building
+                        score.value <= 15L -> R.color.accent_amber
+                        else -> R.color.status_reset
+                    }
+                    binding.sectionQuickStats.progressCountToday.setIndicatorColor(
+                        ContextCompat.getColor(this, colorRes)
+                    )
+                }
+                else -> {}
+            }
+        }
+    }
+
+    private fun updateRecordCards(scores: List<ScoreData>?) {
+        if (scores.isNullOrEmpty()) return
+        for (score in scores) {
+            when (score.type) {
+                ScoreData.StatType.STREAK -> if (score.label.contains("Best")) {
+                    binding.sectionRecords.textAllTimeBest.text = "${score.value} days"
+                }
+                ScoreData.StatType.COUNT -> {
+                    binding.sectionRecords.textTotalSessions.text = score.value.toString()
+                }
+                else -> {}
+            }
+        }
+    }
+
+    /**
+     * Renders the "Subjective Scales" stats card — latest weekly value per
+     * metric plus the delta against the prior entry. Period-agnostic (the
+     * scales are captured weekly, so the period-chip framing doesn't apply).
+     * Tap the CTA → opens the carousel to update this week's check-in.
+     */
+    private fun updateSelfEvalStats() {
+        val sectionRoot = binding.sectionSelfEvalStats.root
+        val rowsGroup = sectionRoot.findViewById<android.widget.LinearLayout>(R.id.groupSelfEvalStatRows)
+        val empty = sectionRoot.findViewById<android.widget.TextView>(R.id.textSelfEvalStatsEmpty)
+        val openBtn = sectionRoot.findViewById<com.google.android.material.button.MaterialButton>(R.id.btnSelfEvalStatsOpen)
+        val store = com.smokless.smokeless.util.WeeklySelfEvalStore(applicationContext)
+        val inflater = layoutInflater
+        val numFmt = DecimalFormat("0.#")
+
+        rowsGroup.removeAllViews()
+        var anyRendered = false
+        for ((key, label) in SELF_EVAL_DIGEST_LABELS) {
+            val recent = store.recent(key, limit = 4)
+            if (recent.isEmpty()) continue
+            anyRendered = true
+
+            val row = inflater.inflate(R.layout.item_self_eval_stat_row, rowsGroup, false)
+            val labelView = row.findViewById<android.widget.TextView>(R.id.textStatRowLabel)
+            val sparklineView = row.findViewById<android.widget.TextView>(R.id.textStatRowSparkline)
+            val valueView = row.findViewById<android.widget.TextView>(R.id.textStatRowValue)
+            val deltaView = row.findViewById<android.widget.TextView>(R.id.textStatRowDelta)
+
+            labelView.text = label
+            val latest = recent.first()
+            valueView.text = numFmt.format(latest.value)
+
+            if (recent.size >= 2) {
+                val prior = recent[1]
+                val delta = latest.value - prior.value
+                val absStr = numFmt.format(kotlin.math.abs(delta))
+                // Direction-only badge — "no judgment" per the cessation
+                // manifesto. Polarities differ across these scales (↓ cough
+                // is desirable, ↓ smell isn't), so the owner reads the
+                // direction; the app doesn't moralise.
+                val badge = when {
+                    kotlin.math.abs(delta) < 0.5 -> "→ steady"
+                    delta > 0 -> "↑ +$absStr"
+                    else -> "↓ −$absStr"
+                }
+                deltaView.text = badge
+                deltaView.setTextColor(ContextCompat.getColor(this, R.color.text_secondary))
+                deltaView.visibility = View.VISIBLE
+            } else {
+                deltaView.visibility = View.GONE
+            }
+
+            // Oldest → newest sparkline so the trend reads left-to-right.
+            val ordered = recent.reversed()
+            sparklineView.text = ordered.joinToString(" → ") { numFmt.format(it.value) }
+
+            rowsGroup.addView(row)
+        }
+        empty.visibility = if (anyRendered) View.GONE else View.VISIBLE
+        openBtn.setOnClickListener {
+            startActivity(Intent(this, WeeklySelfEvalActivity::class.java))
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_stats.xml
+++ b/app/src/main/res/drawable/ic_stats.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/text_primary">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M5,20 L5,12 L8,12 L8,20 Z M10.5,20 L10.5,4 L13.5,4 L13.5,20 Z M16,20 L16,8 L19,8 L19,20 Z" />
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -43,7 +43,7 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 android:paddingHorizontal="20dp"
-                android:paddingBottom="260dp">
+                android:paddingBottom="180dp">
 
                 <include android:id="@+id/sectionRecoveryHero" layout="@layout/section_recovery_hero" />
 
@@ -79,13 +79,13 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
-    <!-- Floating: today's-pace band + FABs (above the stats sheet) -->
+    <!-- Floating: today's-pace band + FABs -->
     <LinearLayout
         android:id="@+id/floatingActions"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
-        android:layout_marginBottom="68dp"
+        android:layout_marginBottom="24dp"
         android:orientation="vertical"
         android:gravity="center"
         android:paddingHorizontal="20dp">
@@ -129,75 +129,5 @@
         </LinearLayout>
 
     </LinearLayout>
-
-    <!-- Stats bottom sheet — drag up for charts, records, period stats -->
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/statsSheet"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/surface_card"
-        android:clipToPadding="false"
-        app:behavior_hideable="false"
-        app:behavior_peekHeight="56dp"
-        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-
-            <!-- Drag handle + label (this is the peek) -->
-            <LinearLayout
-                android:id="@+id/statsSheetHandle"
-                android:layout_width="match_parent"
-                android:layout_height="56dp"
-                android:orientation="vertical"
-                android:gravity="center"
-                android:clickable="true"
-                android:focusable="true"
-                android:background="?attr/selectableItemBackground">
-
-                <View
-                    android:layout_width="40dp"
-                    android:layout_height="4dp"
-                    android:background="@color/divider" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
-                    android:text="Stats ▴"
-                    android:textColor="@color/text_secondary"
-                    android:textSize="12sp"
-                    android:textAllCaps="true"
-                    android:letterSpacing="0.1"
-                    android:fontFamily="sans-serif-medium" />
-
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:paddingHorizontal="20dp"
-                android:paddingBottom="40dp">
-
-                <include android:id="@+id/sectionQuickStats" layout="@layout/section_quick_stats" />
-
-                <include android:id="@+id/sectionReductionTrend" layout="@layout/section_reduction_trend" />
-
-                <include android:id="@+id/sectionStatistics" layout="@layout/section_statistics" />
-
-                <include android:id="@+id/sectionSelfEvalStats" layout="@layout/section_self_eval_stats" />
-
-                <include android:id="@+id/sectionCharts" layout="@layout/section_charts" />
-
-                <include android:id="@+id/sectionRecords" layout="@layout/section_records" />
-
-            </LinearLayout>
-
-        </LinearLayout>
-
-    </androidx.core.widget.NestedScrollView>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_stats.xml
+++ b/app/src/main/res/layout/activity_stats.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/bg_gradient">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        app:elevation="0dp">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@android:color/transparent"
+            app:navigationIcon="@drawable/ic_back"
+            app:navigationIconTint="@color/text_primary"
+            app:navigationContentDescription="Go back"
+            app:title="Stats"
+            app:titleTextColor="@color/text_primary" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true"
+        android:clipToPadding="false"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingHorizontal="20dp"
+            android:paddingBottom="40dp">
+
+            <include android:id="@+id/sectionQuickStats" layout="@layout/section_quick_stats" />
+
+            <include android:id="@+id/sectionReductionTrend" layout="@layout/section_reduction_trend" />
+
+            <include android:id="@+id/sectionStatistics" layout="@layout/section_statistics" />
+
+            <include android:id="@+id/sectionSelfEvalStats" layout="@layout/section_self_eval_stats" />
+
+            <include android:id="@+id/sectionCharts" layout="@layout/section_charts" />
+
+            <include android:id="@+id/sectionRecords" layout="@layout/section_records" />
+
+        </LinearLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -2,6 +2,11 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/action_stats"
+        android:icon="@drawable/ic_stats"
+        android:title="Stats"
+        app:showAsAction="always" />
+    <item
         android:id="@+id/action_achievements"
         android:icon="@drawable/ic_trophy"
         android:title="Achievements"


### PR DESCRIPTION
## Summary
- Adds a weekly subjective cessation self-eval (smell, taste, cough, sputum, breath ease, smoker-identity) as a one-question-per-slide carousel, with nudge notifications that keep firing after the user quits — closes #46
- Captures the same six ratings during onboarding so users land with a real baseline instead of an empty trend, and surfaces the running ratings + sparklines in the statistics surface
- Promotes the stats & metrics into a dedicated [StatsActivity](app/src/main/java/com/smokless/smokeless/StatsActivity.kt) (MaterialToolbar + back arrow + scrollable card stack), matching the Bios dashboard pattern (sleep / biomarkers / trends) instead of burying the same six sections in a bottom sheet on the home screen
- Home screen now keeps real-time context only (recovery hero, weekly digest, trigger map, timeline, FAB); a new bar-chart icon in the toolbar opens the Stats screen

## Test plan
- [ ] Onboarding: run a fresh install → answer the six baseline sliders → verify the values appear in the Stats screen's Subjective Scales card on first launch
- [ ] Weekly check-in: tap the digest CTA → swipe through all six slides → confirm latest values + deltas update on the stats card
- [ ] Verify the weekly nudge fires even after the user has marked their primary substance as quit
- [ ] Open Stats from the toolbar bar-chart icon → period chips (Today/Week/Month/Year/All) switch quick-stats, period count, statistics, and charts coherently
- [ ] Back arrow on Stats returns to home; recovery hero / weekly digest / trigger map still render on home

🤖 Generated with [Claude Code](https://claude.com/claude-code)