### PR TITLE
Self-eval stats + baseline, dedicated stats screen, substance-stacked bars

### DIFF
--- a/app/src/main/java/com/smokless/smokeless/StatsActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/StatsActivity.kt
@@ -210,7 +210,14 @@ class StatsActivity : AppCompatActivity() {
         barChart.setScaleEnabled(false)
         barChart.setPinchZoom(false)
         barChart.setDrawGridBackground(false)
-        barChart.legend.isEnabled = false
+        barChart.legend.apply {
+            isEnabled = true
+            textColor = ContextCompat.getColor(this@StatsActivity, R.color.text_secondary)
+            textSize = 10f
+            form = com.github.mikephil.charting.components.Legend.LegendForm.SQUARE
+            formSize = 8f
+            xEntrySpace = 12f
+        }
         barChart.extraBottomOffset = 8f
         barChart.setFitBars(true)
         barChart.setNoDataText("Start tracking to see your patterns here")
@@ -291,14 +298,23 @@ class StatsActivity : AppCompatActivity() {
         val dataMaxValue = kotlin.math.max(maxCount.toFloat(), maxAverage.toFloat())
         val chartMaxValue = kotlin.math.max(dataMaxValue * 1.2f, 5f)
 
-        val barEntries = data.dailyCounts.mapIndexed { index, count ->
-            BarEntry(index.toFloat(), count.toFloat())
+        // Stacked bar: tobacco (orange) sits below cannabis (dark green) so the
+        // owner can read both the total height (overall load) and the slice
+        // proportions (which substance dominated the day).
+        val barEntries = data.dailyCounts.mapIndexed { index, _ ->
+            val tobacco = data.tobaccoCounts.getOrNull(index)?.toFloat() ?: 0f
+            val cannabis = data.cannabisCounts.getOrNull(index)?.toFloat() ?: 0f
+            BarEntry(index.toFloat(), floatArrayOf(tobacco, cannabis))
         }
         if (barEntries.isNotEmpty()) {
             binding.sectionCharts.barChart.visibility = View.VISIBLE
             binding.sectionCharts.emptyStateBar.visibility = View.GONE
-            val barDataSet = BarDataSet(barEntries, "Cigarettes").apply {
-                color = ContextCompat.getColor(this@StatsActivity, R.color.accent_amber)
+            val barDataSet = BarDataSet(barEntries, "Sessions").apply {
+                setColors(
+                    ContextCompat.getColor(this@StatsActivity, R.color.chart_substance_tobacco),
+                    ContextCompat.getColor(this@StatsActivity, R.color.chart_substance_cannabis),
+                )
+                stackLabels = arrayOf("Tobacco", "Cannabis")
                 setDrawValues(true)
                 valueTextColor = ContextCompat.getColor(this@StatsActivity, R.color.text_secondary)
                 valueTextSize = 9f

--- a/app/src/main/java/com/smokless/smokeless/StatsActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/StatsActivity.kt
@@ -298,23 +298,22 @@ class StatsActivity : AppCompatActivity() {
         val dataMaxValue = kotlin.math.max(maxCount.toFloat(), maxAverage.toFloat())
         val chartMaxValue = kotlin.math.max(dataMaxValue * 1.2f, 5f)
 
-        // Stacked bar: tobacco (orange) sits below cannabis (dark green) so the
-        // owner can read both the total height (overall load) and the slice
-        // proportions (which substance dominated the day).
+        // Stacked bar: cannabis (dark green) sits at the base, tobacco (orange)
+        // on top — tobacco is the headline substance, so it reads first.
         val barEntries = data.dailyCounts.mapIndexed { index, _ ->
             val tobacco = data.tobaccoCounts.getOrNull(index)?.toFloat() ?: 0f
             val cannabis = data.cannabisCounts.getOrNull(index)?.toFloat() ?: 0f
-            BarEntry(index.toFloat(), floatArrayOf(tobacco, cannabis))
+            BarEntry(index.toFloat(), floatArrayOf(cannabis, tobacco))
         }
         if (barEntries.isNotEmpty()) {
             binding.sectionCharts.barChart.visibility = View.VISIBLE
             binding.sectionCharts.emptyStateBar.visibility = View.GONE
             val barDataSet = BarDataSet(barEntries, "Sessions").apply {
                 setColors(
-                    ContextCompat.getColor(this@StatsActivity, R.color.chart_substance_tobacco),
                     ContextCompat.getColor(this@StatsActivity, R.color.chart_substance_cannabis),
+                    ContextCompat.getColor(this@StatsActivity, R.color.chart_substance_tobacco),
                 )
-                stackLabels = arrayOf("Tobacco", "Cannabis")
+                stackLabels = arrayOf("Cannabis", "Tobacco")
                 setDrawValues(true)
                 valueTextColor = ContextCompat.getColor(this@StatsActivity, R.color.text_secondary)
                 valueTextSize = 9f

--- a/app/src/main/java/com/smokless/smokeless/StatsActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/StatsActivity.kt
@@ -48,7 +48,7 @@ class StatsActivity : AppCompatActivity() {
     )
 
     private var currentPeriod = "month"
-    private var currentChartGranularity = "days"
+    private var currentChartRange = "month"
     private var copy: SubstanceCopy = SubstanceCopy.TOBACCO
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -60,7 +60,7 @@ class StatsActivity : AppCompatActivity() {
 
         setupStatsRecycler()
         setupChipGroup()
-        setupChartGranularityChips()
+        setupChartRangeChips()
         setupCharts()
         setupCollapsibleSections()
         observeViewModel()
@@ -132,34 +132,31 @@ class StatsActivity : AppCompatActivity() {
         binding.sectionStatistics.chipMonth.isChecked = true
     }
 
-    private fun setupChartGranularityChips() {
-        binding.sectionCharts.chipGroupChartGranularity.setOnCheckedStateChangeListener { _, checkedIds ->
+    private fun setupChartRangeChips() {
+        binding.sectionCharts.chipGroupChartRange.setOnCheckedStateChangeListener { _, checkedIds ->
             if (checkedIds.isEmpty()) return@setOnCheckedStateChangeListener
-            currentChartGranularity = when (checkedIds[0]) {
-                R.id.chipGrainWeeks -> "weeks"
-                R.id.chipGrainMonths -> "months"
-                R.id.chipGrainYears -> "years"
-                else -> "days"
+            currentChartRange = when (checkedIds[0]) {
+                R.id.chipRangeWeek -> "week"
+                R.id.chipRangeYear -> "year"
+                else -> "month"
             }
             updateChartLabels()
-            viewModel.setChartGranularity(currentChartGranularity)
+            viewModel.setChartRange(currentChartRange)
         }
-        binding.sectionCharts.chipGrainDays.isChecked = true
+        binding.sectionCharts.chipRangeMonth.isChecked = true
         updateChartLabels()
     }
 
     private fun updateChartLabels() {
-        binding.sectionCharts.textTrendChartTitle.text = when (currentChartGranularity) {
-            "weeks" -> "Weekly Trend"
-            "months" -> "Monthly Trend"
-            "years" -> "Yearly Trend"
-            else -> "Daily Trend"
+        binding.sectionCharts.textTrendChartTitle.text = when (currentChartRange) {
+            "week" -> "Trend — last week"
+            "year" -> "Trend — last year"
+            else -> "Trend — last month"
         }
-        binding.sectionCharts.textBarChartTitle.text = when (currentChartGranularity) {
-            "weeks" -> "Weekly Count"
-            "months" -> "Monthly Count"
-            "years" -> "Yearly Count"
-            else -> "Daily Count"
+        binding.sectionCharts.textBarChartTitle.text = when (currentChartRange) {
+            "week" -> "Last 7 days"
+            "year" -> "Last 12 months"
+            else -> "Last 30 days"
         }
     }
 
@@ -374,10 +371,8 @@ class StatsActivity : AppCompatActivity() {
             binding.sectionCharts.emptyStateBar.visibility = View.VISIBLE
         }
 
-        val avgUnit = when (currentChartGranularity) {
-            "weeks" -> "/wk"
-            "months" -> "/mo"
-            "years" -> "/yr"
+        val avgUnit = when (currentChartRange) {
+            "year" -> "/mo"
             else -> "/day"
         }
         binding.sectionCharts.textBarChartAvg.text =

--- a/app/src/main/java/com/smokless/smokeless/StatsActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/StatsActivity.kt
@@ -48,6 +48,7 @@ class StatsActivity : AppCompatActivity() {
     )
 
     private var currentPeriod = "month"
+    private var currentChartGranularity = "days"
     private var copy: SubstanceCopy = SubstanceCopy.TOBACCO
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -59,6 +60,7 @@ class StatsActivity : AppCompatActivity() {
 
         setupStatsRecycler()
         setupChipGroup()
+        setupChartGranularityChips()
         setupCharts()
         setupCollapsibleSections()
         observeViewModel()
@@ -106,9 +108,9 @@ class StatsActivity : AppCompatActivity() {
             val statsRecycler = binding.sectionStatistics.recyclerStats
             val quickStats = binding.sectionQuickStats.root
             statsRecycler.animate().alpha(0f).setDuration(150).withEndAction {
-                viewModel.setChartPeriod(currentPeriod)
+                // The chart has its own granularity selector now; period
+                // chip only drives the stats list / period highlights.
                 updateStatsForPeriod()
-                updateChartLabels()
 
                 val scores = when (currentPeriod) {
                     "day" -> viewModel.dayScores.value
@@ -130,17 +132,33 @@ class StatsActivity : AppCompatActivity() {
         binding.sectionStatistics.chipMonth.isChecked = true
     }
 
-    private fun updateChartLabels() {
-        binding.sectionCharts.textTrendChartTitle.text = when (currentPeriod) {
-            "day" -> "Hourly Trend"
-            "week" -> "Daily Trend"
-            "month" -> "7-Day Average Trend"
-            "year" -> "Monthly Trend"
-            "all" -> "Long-term Trend"
-            else -> "Trend"
+    private fun setupChartGranularityChips() {
+        binding.sectionCharts.chipGroupChartGranularity.setOnCheckedStateChangeListener { _, checkedIds ->
+            if (checkedIds.isEmpty()) return@setOnCheckedStateChangeListener
+            currentChartGranularity = when (checkedIds[0]) {
+                R.id.chipGrainWeeks -> "weeks"
+                R.id.chipGrainMonths -> "months"
+                R.id.chipGrainYears -> "years"
+                else -> "days"
+            }
+            updateChartLabels()
+            viewModel.setChartGranularity(currentChartGranularity)
         }
-        binding.sectionCharts.textBarChartTitle.text = when (currentPeriod) {
-            "day" -> "Hourly Count"
+        binding.sectionCharts.chipGrainDays.isChecked = true
+        updateChartLabels()
+    }
+
+    private fun updateChartLabels() {
+        binding.sectionCharts.textTrendChartTitle.text = when (currentChartGranularity) {
+            "weeks" -> "Weekly Trend"
+            "months" -> "Monthly Trend"
+            "years" -> "Yearly Trend"
+            else -> "Daily Trend"
+        }
+        binding.sectionCharts.textBarChartTitle.text = when (currentChartGranularity) {
+            "weeks" -> "Weekly Count"
+            "months" -> "Monthly Count"
+            "years" -> "Yearly Count"
             else -> "Daily Count"
         }
     }
@@ -356,11 +374,14 @@ class StatsActivity : AppCompatActivity() {
             binding.sectionCharts.emptyStateBar.visibility = View.VISIBLE
         }
 
-        val avgLabel = when (currentPeriod) {
-            "day" -> "Total: ${data.dailyCounts.sum()}"
-            else -> String.format("Avg: %.1f/day", data.avgDailyCount)
+        val avgUnit = when (currentChartGranularity) {
+            "weeks" -> "/wk"
+            "months" -> "/mo"
+            "years" -> "/yr"
+            else -> "/day"
         }
-        binding.sectionCharts.textBarChartAvg.text = avgLabel
+        binding.sectionCharts.textBarChartAvg.text =
+            String.format("Avg: %.1f%s", data.avgDailyCount, avgUnit)
 
         val lineEntries = data.movingAverage.mapIndexed { index, avg ->
             Entry(index.toFloat(), avg.toFloat())

--- a/app/src/main/java/com/smokless/smokeless/StatsActivity.kt
+++ b/app/src/main/java/com/smokless/smokeless/StatsActivity.kt
@@ -317,9 +317,31 @@ class StatsActivity : AppCompatActivity() {
                 setDrawValues(true)
                 valueTextColor = ContextCompat.getColor(this@StatsActivity, R.color.text_secondary)
                 valueTextSize = 9f
+                // Only label the bar's total. The renderer calls
+                // getBarStackedLabel once per stack segment in array order;
+                // we emit the total only on the topmost non-zero segment so
+                // the bar carries a single number, never a per-slice
+                // breakdown.
                 valueFormatter = object : ValueFormatter() {
-                    override fun getFormattedValue(value: Float): String {
-                        return if (value > 0) value.toInt().toString() else ""
+                    private var lastEntry: BarEntry? = null
+                    private var segmentsSeen = 0
+
+                    override fun getBarStackedLabel(value: Float, stackedEntry: BarEntry?): String {
+                        val entry = stackedEntry ?: return ""
+                        val vals = entry.yVals
+                            ?: return if (entry.y > 0f) entry.y.toInt().toString() else ""
+
+                        if (entry !== lastEntry) {
+                            lastEntry = entry
+                            segmentsSeen = 0
+                        }
+                        val idx = segmentsSeen
+                        segmentsSeen++
+
+                        val topIdx = vals.indices.lastOrNull { vals[it] > 0f } ?: return ""
+                        if (idx != topIdx) return ""
+                        val total = entry.y.toInt()
+                        return if (total > 0) total.toString() else ""
                     }
                 }
             }

--- a/app/src/main/java/com/smokless/smokeless/ui/main/ChartData.kt
+++ b/app/src/main/java/com/smokless/smokeless/ui/main/ChartData.kt
@@ -11,7 +11,9 @@ package com.smokless.smokeless.ui.main
  * - Optimized label generation to prevent chart overcrowding
  */
 data class ChartData(
-    val dailyCounts: List<Int>,          // Cigarettes per day/hour (includes 0 counts)
+    val dailyCounts: List<Int>,          // Total sessions per day/hour (includes 0 counts)
+    val tobaccoCounts: List<Int>,        // Tobacco-only sessions per bucket, aligned with dailyCounts
+    val cannabisCounts: List<Int>,       // Cannabis-only sessions per bucket, aligned with dailyCounts
     val labels: List<String>,            // Date/time labels for x-axis
     val movingAverage: List<Double>,     // Adaptive moving average for trend line
     val avgDailyCount: Double,           // Overall average for the period

--- a/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
@@ -679,9 +679,30 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         } else {
             ScoreCalculator.getDailyCountsForScope(sessions, period)
         }
-        
+
+        // Per-substance series — same bucket keys as countsMap, so the stacked
+        // bar can align tobacco + cannabis slices index-for-index.
+        val tobaccoSessions = sessions.filter {
+            it.substance == com.smokless.smokeless.data.entity.Substance.TOBACCO
+        }
+        val cannabisSessions = sessions.filter {
+            it.substance == com.smokless.smokeless.data.entity.Substance.CANNABIS
+        }
+        val tobaccoMap = if (period == "day") {
+            ScoreCalculator.getHourlyCountsForToday(tobaccoSessions)
+        } else {
+            ScoreCalculator.getDailyCountsForScope(tobaccoSessions, period)
+        }
+        val cannabisMap = if (period == "day") {
+            ScoreCalculator.getHourlyCountsForToday(cannabisSessions)
+        } else {
+            ScoreCalculator.getDailyCountsForScope(cannabisSessions, period)
+        }
+
         val dailyCounts = countsMap.values.toList()
         val dateKeys = countsMap.keys.toList()
+        val tobaccoCounts = dateKeys.map { tobaccoMap[it] ?: 0 }
+        val cannabisCounts = dateKeys.map { cannabisMap[it] ?: 0 }
         
         // Skip if no data at all
         if (dailyCounts.isEmpty()) {
@@ -708,6 +729,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         
         _chartData.postValue(ChartData(
             dailyCounts = dailyCounts,
+            tobaccoCounts = tobaccoCounts,
+            cannabisCounts = cannabisCounts,
             labels = labels,
             movingAverage = movingAverage,
             avgDailyCount = avgDailyCount,

--- a/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
@@ -158,6 +158,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     
     private var lastTimestamp = 0L
     private var currentChartPeriod = "month"
+    // Chart bucketing — independent from currentChartPeriod which still drives
+    // the rest of the stats screen. Default "days" matches the prior month-
+    // period chart appearance (30 daily bars).
+    private var currentChartGranularity = "days"
     private var currentGoalPeriod = "month"  // Track period for goal calculation
     private var lastNotifiedHours = 0L  // Track last milestone notification
     
@@ -356,6 +360,18 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             calculateChartData(sessions, period)
         }
     }
+
+    /**
+     * Switch the x-axis bucketing on the chart. Pulls all sessions (the chart
+     * defines its own range per granularity) and recalculates.
+     */
+    fun setChartGranularity(granularity: String) {
+        currentChartGranularity = granularity
+        AppDatabase.databaseExecutor.execute {
+            val sessions = repository.getAllSessionsSync()
+            calculateChartDataByGranularity(sessions, granularity)
+        }
+    }
     
     /**
      * Set the goal period - updates goal and progress calculation
@@ -435,9 +451,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         _weekScores.postValue(calculateScopeScores(repository.getSessionsForScope("week"), "week", copy))
         _dayScores.postValue(calculateScopeScores(repository.getSessionsForScope("day"), "day", copy))
         
-        // Calculate chart data
-        val chartSessions = repository.getSessionsForScope(currentChartPeriod)
-        calculateChartData(chartSessions, currentChartPeriod)
+        // Calculate chart data — bucketed by the chart's own granularity,
+        // independent of currentChartPeriod (which drives the rest of the
+        // stats screen, not the chart).
+        calculateChartDataByGranularity(allSessions, currentChartGranularity)
         
         // Calculate money saved for current period
         val moneySessions = repository.getSessionsForScope(currentGoalPeriod)
@@ -741,7 +758,119 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             trendPercentage = trendPercentage
         ))
     }
-    
+
+    /**
+     * Chart-only path: bucket by granularity (days/weeks/months/years) and
+     * pack the result into ChartData. Decoupled from currentChartPeriod —
+     * the chart picks its own range based on grain.
+     */
+    private fun calculateChartDataByGranularity(
+        sessions: List<com.smokless.smokeless.data.entity.SmokingSession>,
+        granularity: String,
+    ) {
+        val countsMap = ScoreCalculator.getCountsByGranularity(sessions, granularity)
+        val tobaccoSessions = sessions.filter {
+            it.substance == com.smokless.smokeless.data.entity.Substance.TOBACCO
+        }
+        val cannabisSessions = sessions.filter {
+            it.substance == com.smokless.smokeless.data.entity.Substance.CANNABIS
+        }
+        val tobaccoMap = ScoreCalculator.getCountsByGranularity(tobaccoSessions, granularity)
+        val cannabisMap = ScoreCalculator.getCountsByGranularity(cannabisSessions, granularity)
+
+        val dailyCounts = countsMap.values.toList()
+        val keys = countsMap.keys.toList()
+        val tobaccoCounts = keys.map { tobaccoMap[it] ?: 0 }
+        val cannabisCounts = keys.map { cannabisMap[it] ?: 0 }
+
+        if (dailyCounts.isEmpty()) {
+            _chartData.postValue(null)
+            return
+        }
+
+        val labels = generateGranularityLabels(keys, granularity)
+        val windowSize = getMovingAverageWindowForGrain(granularity, dailyCounts.size)
+        val movingAverage = calculateMovingAverage(dailyCounts, windowSize)
+        val avgDailyCount = dailyCounts.average()
+        val bestDay = dailyCounts.filter { it > 0 }.minOrNull() ?: 0
+        val worstDay = dailyCounts.maxOrNull() ?: 0
+        val cleanDays = dailyCounts.count { it == 0 }
+        val (isImproving, trendPercentage) = calculateTrendImproved(dailyCounts)
+
+        _chartData.postValue(ChartData(
+            dailyCounts = dailyCounts,
+            tobaccoCounts = tobaccoCounts,
+            cannabisCounts = cannabisCounts,
+            labels = labels,
+            movingAverage = movingAverage,
+            avgDailyCount = avgDailyCount,
+            isImproving = isImproving,
+            bestDay = bestDay,
+            worstDay = worstDay,
+            cleanDays = cleanDays,
+            trendPercentage = trendPercentage,
+        ))
+    }
+
+    private fun generateGranularityLabels(keys: List<String>, granularity: String): List<String> {
+        return when (granularity.lowercase()) {
+            "weeks" -> {
+                val out = SimpleDateFormat("MMM d", Locale.getDefault())
+                val cal = Calendar.getInstance().apply {
+                    firstDayOfWeek = Calendar.MONDAY
+                    minimalDaysInFirstWeek = 4
+                }
+                keys.map { key ->
+                    // "yyyy-Www" → format the Monday of that ISO week as "MMM d".
+                    val parts = key.split("-W")
+                    if (parts.size != 2) return@map key
+                    val year = parts[0].toIntOrNull() ?: return@map key
+                    val week = parts[1].toIntOrNull() ?: return@map key
+                    cal.clear()
+                    cal.firstDayOfWeek = Calendar.MONDAY
+                    cal.minimalDaysInFirstWeek = 4
+                    cal.set(Calendar.YEAR, year)
+                    cal.set(Calendar.WEEK_OF_YEAR, week)
+                    cal.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
+                    out.format(cal.time)
+                }
+            }
+            "months" -> {
+                val parser = SimpleDateFormat("yyyy-MM", Locale.getDefault())
+                val out = SimpleDateFormat("MMM yy", Locale.getDefault())
+                keys.map { key ->
+                    try {
+                        parser.parse(key)?.let { out.format(it) } ?: key
+                    } catch (e: Exception) {
+                        key
+                    }
+                }
+            }
+            "years" -> keys
+            else -> {
+                val parser = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+                val out = SimpleDateFormat("MMM d", Locale.getDefault())
+                keys.map { key ->
+                    try {
+                        parser.parse(key)?.let { out.format(it) } ?: key
+                    } catch (e: Exception) {
+                        key
+                    }
+                }
+            }
+        }
+    }
+
+    private fun getMovingAverageWindowForGrain(granularity: String, dataSize: Int): Int {
+        val base = when (granularity.lowercase()) {
+            "weeks" -> 4
+            "months" -> 3
+            "years" -> 2
+            else -> 7  // days
+        }
+        return kotlin.math.min(base, kotlin.math.max(1, dataSize / 3))
+    }
+
     /**
      * Get adaptive moving average window size based on period
      */

--- a/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/smokless/smokeless/ui/main/MainViewModel.kt
@@ -158,10 +158,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     
     private var lastTimestamp = 0L
     private var currentChartPeriod = "month"
-    // Chart bucketing — independent from currentChartPeriod which still drives
-    // the rest of the stats screen. Default "days" matches the prior month-
-    // period chart appearance (30 daily bars).
-    private var currentChartGranularity = "days"
+    // Chart range — independent from currentChartPeriod (which still drives
+    // the rest of the stats screen). Default "month" matches the prior
+    // chart appearance (30 daily bars).
+    private var currentChartRange = "month"
     private var currentGoalPeriod = "month"  // Track period for goal calculation
     private var lastNotifiedHours = 0L  // Track last milestone notification
     
@@ -362,14 +362,14 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     /**
-     * Switch the x-axis bucketing on the chart. Pulls all sessions (the chart
-     * defines its own range per granularity) and recalculates.
+     * Switch the chart's time range. Pulls all sessions (the chart picks
+     * its own bucket size per range) and recalculates.
      */
-    fun setChartGranularity(granularity: String) {
-        currentChartGranularity = granularity
+    fun setChartRange(range: String) {
+        currentChartRange = range
         AppDatabase.databaseExecutor.execute {
             val sessions = repository.getAllSessionsSync()
-            calculateChartDataByGranularity(sessions, granularity)
+            calculateChartDataByRange(sessions, range)
         }
     }
     
@@ -451,10 +451,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         _weekScores.postValue(calculateScopeScores(repository.getSessionsForScope("week"), "week", copy))
         _dayScores.postValue(calculateScopeScores(repository.getSessionsForScope("day"), "day", copy))
         
-        // Calculate chart data — bucketed by the chart's own granularity,
+        // Calculate chart data — chart has its own range selector,
         // independent of currentChartPeriod (which drives the rest of the
         // stats screen, not the chart).
-        calculateChartDataByGranularity(allSessions, currentChartGranularity)
+        calculateChartDataByRange(allSessions, currentChartRange)
         
         // Calculate money saved for current period
         val moneySessions = repository.getSessionsForScope(currentGoalPeriod)
@@ -760,23 +760,22 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     /**
-     * Chart-only path: bucket by granularity (days/weeks/months/years) and
-     * pack the result into ChartData. Decoupled from currentChartPeriod —
-     * the chart picks its own range based on grain.
+     * Chart-only path: window the data by user-selected range (week/month/year)
+     * and bucket it accordingly. Decoupled from currentChartPeriod.
      */
-    private fun calculateChartDataByGranularity(
+    private fun calculateChartDataByRange(
         sessions: List<com.smokless.smokeless.data.entity.SmokingSession>,
-        granularity: String,
+        range: String,
     ) {
-        val countsMap = ScoreCalculator.getCountsByGranularity(sessions, granularity)
+        val countsMap = ScoreCalculator.getCountsByRange(sessions, range)
         val tobaccoSessions = sessions.filter {
             it.substance == com.smokless.smokeless.data.entity.Substance.TOBACCO
         }
         val cannabisSessions = sessions.filter {
             it.substance == com.smokless.smokeless.data.entity.Substance.CANNABIS
         }
-        val tobaccoMap = ScoreCalculator.getCountsByGranularity(tobaccoSessions, granularity)
-        val cannabisMap = ScoreCalculator.getCountsByGranularity(cannabisSessions, granularity)
+        val tobaccoMap = ScoreCalculator.getCountsByRange(tobaccoSessions, range)
+        val cannabisMap = ScoreCalculator.getCountsByRange(cannabisSessions, range)
 
         val dailyCounts = countsMap.values.toList()
         val keys = countsMap.keys.toList()
@@ -788,8 +787,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             return
         }
 
-        val labels = generateGranularityLabels(keys, granularity)
-        val windowSize = getMovingAverageWindowForGrain(granularity, dailyCounts.size)
+        val labels = generateRangeLabels(keys, range)
+        val windowSize = getMovingAverageWindowForRange(range, dailyCounts.size)
         val movingAverage = calculateMovingAverage(dailyCounts, windowSize)
         val avgDailyCount = dailyCounts.average()
         val bestDay = dailyCounts.filter { it > 0 }.minOrNull() ?: 0
@@ -812,32 +811,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         ))
     }
 
-    private fun generateGranularityLabels(keys: List<String>, granularity: String): List<String> {
-        return when (granularity.lowercase()) {
-            "weeks" -> {
-                val out = SimpleDateFormat("MMM d", Locale.getDefault())
-                val cal = Calendar.getInstance().apply {
-                    firstDayOfWeek = Calendar.MONDAY
-                    minimalDaysInFirstWeek = 4
-                }
-                keys.map { key ->
-                    // "yyyy-Www" → format the Monday of that ISO week as "MMM d".
-                    val parts = key.split("-W")
-                    if (parts.size != 2) return@map key
-                    val year = parts[0].toIntOrNull() ?: return@map key
-                    val week = parts[1].toIntOrNull() ?: return@map key
-                    cal.clear()
-                    cal.firstDayOfWeek = Calendar.MONDAY
-                    cal.minimalDaysInFirstWeek = 4
-                    cal.set(Calendar.YEAR, year)
-                    cal.set(Calendar.WEEK_OF_YEAR, week)
-                    cal.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
-                    out.format(cal.time)
-                }
-            }
-            "months" -> {
+    private fun generateRangeLabels(keys: List<String>, range: String): List<String> {
+        return when (range.lowercase()) {
+            "year" -> {
+                // keys are "yyyy-MM" — render as "MMM"
                 val parser = SimpleDateFormat("yyyy-MM", Locale.getDefault())
-                val out = SimpleDateFormat("MMM yy", Locale.getDefault())
+                val out = SimpleDateFormat("MMM", Locale.getDefault())
                 keys.map { key ->
                     try {
                         parser.parse(key)?.let { out.format(it) } ?: key
@@ -846,8 +825,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     }
                 }
             }
-            "years" -> keys
             else -> {
+                // keys are "yyyy-MM-dd"
                 val parser = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
                 val out = SimpleDateFormat("MMM d", Locale.getDefault())
                 keys.map { key ->
@@ -861,12 +840,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
-    private fun getMovingAverageWindowForGrain(granularity: String, dataSize: Int): Int {
-        val base = when (granularity.lowercase()) {
-            "weeks" -> 4
-            "months" -> 3
-            "years" -> 2
-            else -> 7  // days
+    private fun getMovingAverageWindowForRange(range: String, dataSize: Int): Int {
+        val base = when (range.lowercase()) {
+            "year" -> 3  // 3-month window
+            "week" -> 3  // 3-day window
+            else -> 7    // 7-day window (month range)
         }
         return kotlin.math.min(base, kotlin.math.max(1, dataSize / 3))
     }

--- a/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
@@ -200,50 +200,39 @@ object ScoreCalculator {
     }
 
     /**
-     * Chart bucketing by arbitrary granularity. Used by the stats screen's
-     * chart granularity selector. Each bucket key matches the format we'd
-     * expect for that grain so [generateChartLabels] can format them.
+     * Chart bucketing by time range. Each range picks the bucket size that
+     * gives a readable bar count:
      *
-     *  - "days"   → last 30 daily buckets, keys "yyyy-MM-dd"
-     *  - "weeks"  → last 12 ISO-week buckets, keys "yyyy-Www"
-     *  - "months" → last 12 calendar-month buckets, keys "yyyy-MM"
-     *  - "years"  → all years from earliest session to now, keys "yyyy"
+     *  - "week"  → last 7 daily buckets, keys "yyyy-MM-dd"
+     *  - "month" → last 30 daily buckets, keys "yyyy-MM-dd"
+     *  - "year"  → last 12 monthly buckets, keys "yyyy-MM"
      *
      * Zero-fills empty buckets so the chart shows continuity.
      */
-    fun getCountsByGranularity(
+    fun getCountsByRange(
         sessions: List<SmokingSession>,
-        granularity: String,
-    ): LinkedHashMap<String, Int> = when (granularity.lowercase()) {
-        "weeks" -> getWeeklyCounts(sessions, weeksBack = 12)
-        "months" -> getMonthlyCounts(sessions, monthsBack = 12)
-        "years" -> getYearlyCounts(sessions)
-        else -> getDailyCountsForScope(sessions, "month")
+        range: String,
+    ): LinkedHashMap<String, Int> = when (range.lowercase()) {
+        "year" -> getMonthlyCounts(sessions, monthsBack = 12)
+        "week" -> getDailyCountsBack(sessions, daysBack = 7)
+        else -> getDailyCountsBack(sessions, daysBack = 30)
     }
 
-    private fun getWeeklyCounts(
+    private fun getDailyCountsBack(
         sessions: List<SmokingSession>,
-        weeksBack: Int,
+        daysBack: Int,
     ): LinkedHashMap<String, Int> {
         val counts = LinkedHashMap<String, Int>()
-        val keyFormat = SimpleDateFormat("yyyy-'W'ww", Locale.getDefault()).apply {
-            calendar = Calendar.getInstance().apply {
-                firstDayOfWeek = Calendar.MONDAY
-                minimalDaysInFirstWeek = 4
-            }
-        }
+        val keyFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
         val cal = Calendar.getInstance().apply {
-            firstDayOfWeek = Calendar.MONDAY
-            minimalDaysInFirstWeek = 4
-            set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
             set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
             set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
-            add(Calendar.WEEK_OF_YEAR, -(weeksBack - 1))
+            add(Calendar.DAY_OF_YEAR, -(daysBack - 1))
         }
         val endCal = Calendar.getInstance()
         while (!cal.after(endCal)) {
             counts[keyFormat.format(cal.time)] = 0
-            cal.add(Calendar.WEEK_OF_YEAR, 1)
+            cal.add(Calendar.DAY_OF_YEAR, 1)
         }
         for (session in sessions) {
             val key = keyFormat.format(Date(session.timestamp))
@@ -270,29 +259,6 @@ object ScoreCalculator {
         while (!cal.after(endCal)) {
             counts[keyFormat.format(cal.time)] = 0
             cal.add(Calendar.MONTH, 1)
-        }
-        for (session in sessions) {
-            val key = keyFormat.format(Date(session.timestamp))
-            if (counts.containsKey(key)) {
-                counts[key] = counts[key]!! + 1
-            }
-        }
-        return counts
-    }
-
-    private fun getYearlyCounts(sessions: List<SmokingSession>): LinkedHashMap<String, Int> {
-        val counts = LinkedHashMap<String, Int>()
-        val keyFormat = SimpleDateFormat("yyyy", Locale.getDefault())
-        if (sessions.isEmpty()) {
-            counts[keyFormat.format(Date())] = 0
-            return counts
-        }
-        val firstYear = Calendar.getInstance().apply {
-            timeInMillis = sessions.minOf { it.timestamp }
-        }.get(Calendar.YEAR)
-        val thisYear = Calendar.getInstance().get(Calendar.YEAR)
-        for (year in firstYear..thisYear) {
-            counts[year.toString()] = 0
         }
         for (session in sessions) {
             val key = keyFormat.format(Date(session.timestamp))

--- a/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
+++ b/app/src/main/java/com/smokless/smokeless/util/ScoreCalculator.kt
@@ -198,7 +198,111 @@ object ScoreCalculator {
         
         return dailyCounts
     }
-    
+
+    /**
+     * Chart bucketing by arbitrary granularity. Used by the stats screen's
+     * chart granularity selector. Each bucket key matches the format we'd
+     * expect for that grain so [generateChartLabels] can format them.
+     *
+     *  - "days"   → last 30 daily buckets, keys "yyyy-MM-dd"
+     *  - "weeks"  → last 12 ISO-week buckets, keys "yyyy-Www"
+     *  - "months" → last 12 calendar-month buckets, keys "yyyy-MM"
+     *  - "years"  → all years from earliest session to now, keys "yyyy"
+     *
+     * Zero-fills empty buckets so the chart shows continuity.
+     */
+    fun getCountsByGranularity(
+        sessions: List<SmokingSession>,
+        granularity: String,
+    ): LinkedHashMap<String, Int> = when (granularity.lowercase()) {
+        "weeks" -> getWeeklyCounts(sessions, weeksBack = 12)
+        "months" -> getMonthlyCounts(sessions, monthsBack = 12)
+        "years" -> getYearlyCounts(sessions)
+        else -> getDailyCountsForScope(sessions, "month")
+    }
+
+    private fun getWeeklyCounts(
+        sessions: List<SmokingSession>,
+        weeksBack: Int,
+    ): LinkedHashMap<String, Int> {
+        val counts = LinkedHashMap<String, Int>()
+        val keyFormat = SimpleDateFormat("yyyy-'W'ww", Locale.getDefault()).apply {
+            calendar = Calendar.getInstance().apply {
+                firstDayOfWeek = Calendar.MONDAY
+                minimalDaysInFirstWeek = 4
+            }
+        }
+        val cal = Calendar.getInstance().apply {
+            firstDayOfWeek = Calendar.MONDAY
+            minimalDaysInFirstWeek = 4
+            set(Calendar.DAY_OF_WEEK, Calendar.MONDAY)
+            set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
+            add(Calendar.WEEK_OF_YEAR, -(weeksBack - 1))
+        }
+        val endCal = Calendar.getInstance()
+        while (!cal.after(endCal)) {
+            counts[keyFormat.format(cal.time)] = 0
+            cal.add(Calendar.WEEK_OF_YEAR, 1)
+        }
+        for (session in sessions) {
+            val key = keyFormat.format(Date(session.timestamp))
+            if (counts.containsKey(key)) {
+                counts[key] = counts[key]!! + 1
+            }
+        }
+        return counts
+    }
+
+    private fun getMonthlyCounts(
+        sessions: List<SmokingSession>,
+        monthsBack: Int,
+    ): LinkedHashMap<String, Int> {
+        val counts = LinkedHashMap<String, Int>()
+        val keyFormat = SimpleDateFormat("yyyy-MM", Locale.getDefault())
+        val cal = Calendar.getInstance().apply {
+            set(Calendar.DAY_OF_MONTH, 1)
+            set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
+            add(Calendar.MONTH, -(monthsBack - 1))
+        }
+        val endCal = Calendar.getInstance()
+        while (!cal.after(endCal)) {
+            counts[keyFormat.format(cal.time)] = 0
+            cal.add(Calendar.MONTH, 1)
+        }
+        for (session in sessions) {
+            val key = keyFormat.format(Date(session.timestamp))
+            if (counts.containsKey(key)) {
+                counts[key] = counts[key]!! + 1
+            }
+        }
+        return counts
+    }
+
+    private fun getYearlyCounts(sessions: List<SmokingSession>): LinkedHashMap<String, Int> {
+        val counts = LinkedHashMap<String, Int>()
+        val keyFormat = SimpleDateFormat("yyyy", Locale.getDefault())
+        if (sessions.isEmpty()) {
+            counts[keyFormat.format(Date())] = 0
+            return counts
+        }
+        val firstYear = Calendar.getInstance().apply {
+            timeInMillis = sessions.minOf { it.timestamp }
+        }.get(Calendar.YEAR)
+        val thisYear = Calendar.getInstance().get(Calendar.YEAR)
+        for (year in firstYear..thisYear) {
+            counts[year.toString()] = 0
+        }
+        for (session in sessions) {
+            val key = keyFormat.format(Date(session.timestamp))
+            if (counts.containsKey(key)) {
+                counts[key] = counts[key]!! + 1
+            }
+        }
+        return counts
+    }
+
     /**
      * Calculate current streak of clean days (from today backwards)
      */

--- a/app/src/main/res/layout/section_charts.xml
+++ b/app/src/main/res/layout/section_charts.xml
@@ -57,6 +57,73 @@
         android:orientation="vertical"
         android:visibility="gone">
 
+    <!-- Chart granularity selector — controls x-axis bucketing for both charts. -->
+    <HorizontalScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        android:scrollbars="none">
+
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/chipGroupChartGranularity"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:singleSelection="true"
+            app:selectionRequired="true">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chipGrainDays"
+                style="@style/Widget.Material3.Chip.Filter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Days"
+                android:textColor="@color/chip_text_color"
+                app:chipBackgroundColor="@color/chip_background_color"
+                app:chipStrokeWidth="0dp"
+                app:checkedIconVisible="false"
+                android:checked="true"
+                app:chipMinHeight="40dp" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chipGrainWeeks"
+                style="@style/Widget.Material3.Chip.Filter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Weeks"
+                android:textColor="@color/chip_text_color"
+                app:chipBackgroundColor="@color/chip_background_color"
+                app:chipStrokeWidth="0dp"
+                app:checkedIconVisible="false"
+                app:chipMinHeight="40dp" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chipGrainMonths"
+                style="@style/Widget.Material3.Chip.Filter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Months"
+                android:textColor="@color/chip_text_color"
+                app:chipBackgroundColor="@color/chip_background_color"
+                app:chipStrokeWidth="0dp"
+                app:checkedIconVisible="false"
+                app:chipMinHeight="40dp" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chipGrainYears"
+                style="@style/Widget.Material3.Chip.Filter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Years"
+                android:textColor="@color/chip_text_color"
+                app:chipBackgroundColor="@color/chip_background_color"
+                app:chipStrokeWidth="0dp"
+                app:checkedIconVisible="false"
+                app:chipMinHeight="40dp" />
+
+        </com.google.android.material.chip.ChipGroup>
+
+    </HorizontalScrollView>
+
     <!-- Line Chart - Smoke-Free Duration Trend -->
     <com.google.android.material.card.MaterialCardView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/section_charts.xml
+++ b/app/src/main/res/layout/section_charts.xml
@@ -57,7 +57,8 @@
         android:orientation="vertical"
         android:visibility="gone">
 
-    <!-- Chart granularity selector — controls x-axis bucketing for both charts. -->
+    <!-- Chart range selector — picks the time window shown by both charts.
+         Each range auto-buckets sensibly: week→daily, month→daily, year→monthly. -->
     <HorizontalScrollView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -65,18 +66,30 @@
         android:scrollbars="none">
 
         <com.google.android.material.chip.ChipGroup
-            android:id="@+id/chipGroupChartGranularity"
+            android:id="@+id/chipGroupChartRange"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:singleSelection="true"
             app:selectionRequired="true">
 
             <com.google.android.material.chip.Chip
-                android:id="@+id/chipGrainDays"
+                android:id="@+id/chipRangeWeek"
                 style="@style/Widget.Material3.Chip.Filter"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Days"
+                android:text="Last week"
+                android:textColor="@color/chip_text_color"
+                app:chipBackgroundColor="@color/chip_background_color"
+                app:chipStrokeWidth="0dp"
+                app:checkedIconVisible="false"
+                app:chipMinHeight="40dp" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chipRangeMonth"
+                style="@style/Widget.Material3.Chip.Filter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Last month"
                 android:textColor="@color/chip_text_color"
                 app:chipBackgroundColor="@color/chip_background_color"
                 app:chipStrokeWidth="0dp"
@@ -85,35 +98,11 @@
                 app:chipMinHeight="40dp" />
 
             <com.google.android.material.chip.Chip
-                android:id="@+id/chipGrainWeeks"
+                android:id="@+id/chipRangeYear"
                 style="@style/Widget.Material3.Chip.Filter"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Weeks"
-                android:textColor="@color/chip_text_color"
-                app:chipBackgroundColor="@color/chip_background_color"
-                app:chipStrokeWidth="0dp"
-                app:checkedIconVisible="false"
-                app:chipMinHeight="40dp" />
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chipGrainMonths"
-                style="@style/Widget.Material3.Chip.Filter"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Months"
-                android:textColor="@color/chip_text_color"
-                app:chipBackgroundColor="@color/chip_background_color"
-                app:chipStrokeWidth="0dp"
-                app:checkedIconVisible="false"
-                app:chipMinHeight="40dp" />
-
-            <com.google.android.material.chip.Chip
-                android:id="@+id/chipGrainYears"
-                style="@style/Widget.Material3.Chip.Filter"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Years"
+                android:text="Last year"
                 android:textColor="@color/chip_text_color"
                 app:chipBackgroundColor="@color/chip_background_color"
                 app:chipStrokeWidth="0dp"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -71,6 +71,10 @@
     <!-- Card accent borders -->
     <color name="card_border_glow">#1500E5A0</color>
     <color name="card_border_dim">#10FFFFFF</color>
+
+    <!-- Chart substance palette - distinguishes tobacco vs cannabis in stacked series -->
+    <color name="chart_substance_tobacco">#F97316</color>
+    <color name="chart_substance_cannabis">#2E7D32</color>
     
     <!-- Legacy aliases -->
     <color name="green">#00E5A0</color>


### PR DESCRIPTION
## Summary
- Self-eval ratings now flow end-to-end: onboarding captures a day-0 baseline, the weekly check-in is a one-question-per-slide carousel, and the latest values + sparkline land on the stats surface.
- Stats moved out of the home-screen bottom sheet into a dedicated `StatsActivity` (Scaffold-style screen with toolbar + scrollable card stack, matching the Bios dashboard pattern).
- Daily-count bar is now a substance-stacked bar — cannabis (dark green) at the base, tobacco (orange) on top — with a legend and a single total label per bar.
- Charts gained their own time-range selector ("Last week / Last month / Last year") that auto-buckets: 7 daily bars, 30 daily bars, or 12 monthly bars. Decoupled from the period chip group, which still drives the stats list.
- Weekly check-in nudge keeps firing after the user marks themselves as quit.

## Test plan
- [ ] Onboarding: complete the self-eval baseline page, confirm only touched sliders persist and the values appear on the stats screen
- [ ] Weekly check-in: open the carousel, advance through all six scales, verify the digest reflects the new values
- [ ] Stats screen: tap the bar-chart icon in the home toolbar, scroll through quick stats / reduction / statistics / self-eval / charts / records
- [ ] Stacked bar: log a mix of tobacco and cannabis sessions, confirm bars split into dark-green (cannabis) base + orange (tobacco) top with a legend and a single total on top
- [ ] Chart range chips: switch between Last week / Last month / Last year, confirm bar counts (7 / 30 / 12), titles, and the avg chip unit (/day vs /mo) update accordingly
- [ ] Quit-state nudge: mark quit, confirm the weekly check-in still fires when due

🤖 Generated with [Claude Code](https://claude.com/claude-code)